### PR TITLE
Fix stages not activated by cronjob issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ jobs:
           make component/test/e2e
     - stage: test-e2e
       name: "Test polices from policy-collection repo"
-      if: type = push AND branch = master
+      if: type != pull_request AND branch = master
       script:
         - |
           make
           make policy-collection-test
     - stage: ff
       name: "Fast forwarding GRC repos"
-      if: type = push AND branch = master
+      if: type != pull_request AND branch = master
       scripts: ./build/ff.sh
   
 notifications:


### PR DESCRIPTION
build triggered by cronjob does not run `ff` stage https://travis-ci.com/github/open-cluster-management/governance-policy-framework/builds/182303176
fixed build check