### PR TITLE
remove clusterrole/binding from gatekeeper policy

### DIFF
--- a/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
+++ b/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
@@ -21,36 +21,6 @@ spec:
                 kind: Namespace
                 metadata:
                   name: gatekeeper-system
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1
-                kind: ClusterRole
-                metadata:
-                  name: gatekeeper-operator-openshift-role
-                rules:
-                - apiGroups:
-                  - security.openshift.io
-                  resourceNames:
-                  - anyuid
-                  resources:
-                  - securitycontextconstraints
-                  verbs:
-                  - use
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1
-                kind: RoleBinding
-                metadata:
-                  name: gatekeeper-operator-openshift-binding
-                  namespace: gatekeeper-system
-                roleRef:
-                  apiGroup: rbac.authorization.k8s.io
-                  kind: ClusterRole
-                  name: gatekeeper-operator-openshift-role
-                subjects:
-                - kind: ServiceAccount
-                  name: default
-                  namespace: gatekeeper-system
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
not needed with the latest change to gatekeeper-operator