### PR TITLE
Skip clean up after tests

### DIFF
--- a/build/run-e2e-tests-ui.sh
+++ b/build/run-e2e-tests-ui.sh
@@ -23,4 +23,5 @@ docker run --volume $(pwd)/results:/opt/app-root/src/grc-ui/test-output/e2e \
     --env CYPRESS_TAGS_INCLUDE=$CYPRESS_TAGS_INCLUDE \
     --env CYPRESS_TAGS_EXCLUDE=$CYPRESS_TAGS_EXCLUDE \
     --env MANAGED_CLUSTER_NAME=$MANAGED_CLUSTER_NAME \
+    --env SKIP_CLEANUP=true \
     $DOCKER_URI


### PR DESCRIPTION
Since we have extended and basic UI tests running together, we need to skip the post-cleanup to allow whichever one is still running to complete.