### PR TITLE
Install a specific version of ginkgo for tests

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -23,8 +23,6 @@ COPY vendor ./vendor
 
 RUN ./build/download-clis.sh
 
-RUN go get github.com/onsi/ginkgo/ginkgo
-RUN go get github.com/onsi/gomega/...
-
+RUN GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.14.2
 
 CMD ["./build/run-test-image.sh"]


### PR DESCRIPTION
Previously, the `go get` commands were installing the latest versions of
ginkgo and gomega. But the newest version of gomega does not work with
versions of golang less than 1.16. The version of golang installed in
the image is still 1.15, limited by the ubi repos. This now installs a
known good version of ginkgo - matching what is in the go.mod.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>