### PR TITLE
Add retry for metrics token creation

### DIFF
--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -89,15 +89,23 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		Expect(err).To(BeNil())
 		_, err = common.OcHub("create", "clusterrolebinding", roleBindingName, "--clusterrole=cluster-admin", fmt.Sprintf("--serviceaccount=%s:%s", userNamespace, saName))
 		Expect(err).To(BeNil())
-		tokenNames, err := common.OcHub("get", fmt.Sprintf("serviceaccount/%s", saName), "-n", userNamespace, "-o", "jsonpath={.secrets[*].name}")
-		Expect(err).To(BeNil())
-		tokenNameArr := strings.Split(tokenNames, " ")
+
+		// The secret can take a moment to be created, retry until it is in the cluster.
 		var tokenName string
-		for _, name := range tokenNameArr {
-			if strings.HasPrefix(name, saName+"-token-") {
-				tokenName = name
+		Eventually(func() interface{} {
+			tokenNames, err := common.OcHub("get", fmt.Sprintf("serviceaccount/%s", saName), "-n", userNamespace, "-o", "jsonpath={.secrets[*].name}")
+			if err != nil {
+				return err
 			}
-		}
+			tokenNameArr := strings.Split(tokenNames, " ")
+			for _, name := range tokenNameArr {
+				if strings.HasPrefix(name, saName+"-token-") {
+					tokenName = name
+				}
+			}
+			return tokenName
+		}, defaultTimeoutSeconds, 1).Should(ContainSubstring(saName + "-token-"))
+
 		encodedtoken, err := common.OcHub("get", "secret", tokenName, "-n", userNamespace, "-o", "jsonpath={.data.token}")
 		Expect(err).To(BeNil())
 		decodedToken, err := base64.StdEncoding.DecodeString(encodedtoken)


### PR DESCRIPTION
Usually the token and secret are created automatically, almost
immediately after the serviceaccount is created. So usually no wait is
needed, but if the cluster is busy it might be delayed.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/17491

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>