### PR TITLE
There's a problem with doing the git clones from prow

### DIFF
--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -17,7 +17,7 @@ cloneRepos() {
 	REPOS=$(cat policy-grc-squad/main-branch-sync/repo.txt | grep policy | grep -v framework)
 	for repo in $REPOS; do
 		printf '%s\n' "Updating $repo ...."
-		git clone git@github.com:$repo.git $repo
+		git clone https://github.com/$repo.git $repo
 	done
 }
 


### PR DESCRIPTION
Switch one of the git clones from using ssh to https.  The ssh style
of doing a clone doesn't work in prow.

Signed-off-by: Gus Parvin <gparvin@redhat.com>