### PR TITLE
Enhance Prow checking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test/policy-collection/debug.test
 .go
 bin/
 vendor/
+
+# Log files from build/periodic.sh
+errors.log

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -54,9 +54,18 @@ checkProwJob() {
 
 	rcode=0
 	# This is a hack to get data from the openshift ci prow
-	# sample curl: curl -H "content-type: application/xml" https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/branch-ci-open-cluster-management-iam-policy-controller-release-2.5-publish
-        # which contains this:   var allBuilds = [{"SpyglassLink":"/view/gs/origin-ci-test/logs/branch-ci-open-cluster-management-iam-policy-controller-release-2.5-publish/1468625788839399424","ID":"1468625788839399424","Started":"2021-12-08T16:57:31Z","Duration":103000000000,"Result":"FAILURE","Refs":{"org":"open-cluster-management","repo":"iam-policy-controller","repo_link":"https://github.com/open-cluster-management/iam-policy-controller","base_ref":"release-2.5","base_sha":"567b3597e8324a4c56ec8f1d717ae15d9671e4a8","base_link":"https://github.com/open-cluster-management/iam-policy-controller/compare/d544db4214b4...567b3597e832"}}];
-	echo "Checking prow jobs for a failure with component $component."
+	# sample curl: 
+	# 	curl -H "content-type: application/xml" https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/branch-ci-open-cluster-management-iam-policy-controller-release-2.5-publish
+				# which contains this:
+				# var allBuilds = [
+				# 	{"SpyglassLink":"/view/gs/origin-ci-test/logs/branch-ci-open-cluster-management-iam-policy-controller-release-2.5-publish/1468625788839399424",
+				# 	 "ID":"1468625788839399424","Started":"2021-12-08T16:57:31Z","Duration":103000000000,"Result":"FAILURE",
+				# 	 "Refs":
+				# 		{"org":"open-cluster-management","repo":"iam-policy-controller",
+				# 		 "repo_link":"https://github.com/open-cluster-management/iam-policy-controller",
+				# 		 "base_ref":"release-2.5","base_sha":"567b3597e8324a4c56ec8f1d717ae15d9671e4a8",
+				# 		 "base_link":"https://github.com/open-cluster-management/iam-policy-controller/compare/d544db4214b4...567b3597e832"
+				# 		}}];
 	jobs="publish images latest-image-mirror"
 	for job in $jobs; do
 		OUTPUT=$(curl -s https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/branch-ci-${COMPONENT_ORG}-${component}-release-${release}-${job})
@@ -107,7 +116,7 @@ for repo in $REPOS; do
 			IMAGES=$repo;;
 	esac
 	for release in $CHECK_RELEASES; do
-		echo "Checking for failures with component $component $release ..."
+		echo "Checking for failures with component $repo $release ..."
 		# check the prow job history
 		checkProwJob "$repo" "$release"
 		if [ $? -eq 1 ]; then
@@ -161,13 +170,13 @@ cleanup
 echo ""
 echo "****"
 echo "PROW STATUS REPORT:"
-echo "****"
+echo "***"
 if [ -f ${ERROR_FILE} ]; then
 	# Print the error log to stdout with duplicate lines removed
 	awk '!a[$0]++' ${ERROR_FILE}
 else
 	echo "All checks PASSED!"
 fi
-echo "****"
+echo "***"
 
 exit $rc


### PR DESCRIPTION
- Makes `git` output quiet to minimize irrelevant logs
- Adds scanning for all repos (originally some repos were omitted since they didn't have image builds or images didn't match)
- Adds support for differently named and multiple images (i.e. `grc-ui`/`grc-ui-tests` and `grc-policy-framework-tests`)
- Adds file that only contains errors
- Dumps final log at the end, cleaning up duplicate lines and dumping it all at the end of the script for simplicity when looking through Prow output, for example:

```
****
PROW STATUS REPORT:
****
ERROR: Prow job failure: config-policy-controller 2.5
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-config-policy-controller-release-2.5-publish/1499488879722369024
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-config-policy-controller-release-2.5-latest-image-mirror/1499488879688814592
ERROR: SHA mismatch in pipeline and config-policy-controller 2.5 repositories.
   imageName: config-policy-controller
   pipeline: 52786f10c322b914ab9a82dda6e8a5b85c960324
   config-policy-controller: 144a3968a568a5c42f51329c9bbff10657c09547
ERROR: Prow job failure: governance-policy-addon-controller 2.5
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-governance-policy-addon-controller-release-2.5-publish/1499518350718406656
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-governance-policy-addon-controller-release-2.5-latest-image-mirror/1499518350672269312
ERROR: SHA mismatch in pipeline and governance-policy-addon-controller 2.5 repositories.
   imageName: governance-policy-addon-controller
   pipeline: 5ef0bfdeddcdc4a392d0e60224393eeb7780b21e
   governance-policy-addon-controller: b98007344d1fdf4258378a6b0889d0fdeac1a997
ERROR: Prow job failure: governance-policy-framework 2.5
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-governance-policy-framework-release-2.5-publish/1499608360113147904
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-governance-policy-framework-release-2.5-latest-image-mirror/1499608360083787776
ERROR: SHA mismatch in pipeline and governance-policy-framework 2.5 repositories.
   imageName: grc-policy-framework-tests
   pipeline: 81d321396cfebf601b67e30abd20c70f003b0e11
   governance-policy-framework: 929b5320bec4570fb790e4b41bb24f872e31c601
ERROR: Prow job failure: grc-ui 2.4
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-grc-ui-release-2.4-publish/1499397335522742272
   Link: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stolostron-grc-ui-release-2.4-latest-image-mirror/1499397335451439104
ERROR: SHA mismatch in pipeline and grc-ui 2.4 repositories.
   imageName: grc-ui
   pipeline: e5be8caddb4f0ba587069017862a34f1fa526d8d
   grc-ui: 9d502229e993fa1babb81ac0f12d50f5b8387801
   imageName: grc-ui-tests
****
``` 