### PR TITLE
Upgrade cert manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ kind-deploy-config-policy-controller:
 
 kind-deploy-cert-policy-controller:
 	@echo installing cert-manager on managed
-	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	@echo installing cert-policy-controller on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/main/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/main/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)

--- a/build/install-cert-manager.sh
+++ b/build/install-cert-manager.sh
@@ -7,6 +7,6 @@ if [ $(oc get ns cert-manager | grep Active | wc -l | tr -d '[:space:]') -eq 1 ]
     echo "Cert manager already installed"
 else 
     echo "Install cert manager on managed"
-    oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml
+    oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml
     ./build/wait_for.sh pod -n cert-manager
 fi


### PR DESCRIPTION
v1.0.1 is too old and it crashes due to using
mutatingwebhookconfiguration v1beta1 api

Signed-off-by: Yu Cao <ycao@redhat.com>