### PR TITLE
Fix Gatekeeper test on kind v0.12.0

### DIFF
--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -8,7 +8,7 @@ var (
 	GvrPod                   = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 	GvrNS                    = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
 	GvrRole                  = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
-	GvrCRD                   = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
+	GvrCRD                   = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 	GvrPolicy                = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}
 	GvrPolicySet             = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1beta1", Resource: "policysets"}
 	GvrConfigurationPolicy   = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "configurationpolicies"}


### PR DESCRIPTION
The v0.12.0 release of Kind has removed the CRD v1beta1
Signed-off-by: Yu Cao <ycao@redhat.com>