### PR TITLE
Run policy-collection test first

### DIFF
--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -33,7 +33,7 @@ cp ${MANAGED_KUBE} $DIR/../kubeconfig_managed
 
 echo "===== E2E Test ====="
 echo "* Launching grc policy framework test"
-for TEST_SUITE in integration policy-collection; do
+for TEST_SUITE in policy-collection integration; do
   # Run test suite with reporting
   CGO_ENABLED=0 ginkgo -v --no-color --fail-fast --junit-report=${TEST_SUITE}.xml --output-dir=test-output test/${TEST_SUITE} -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
 

--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -8,7 +8,7 @@ if [[ ${FAIL_FAST} == "true" ]]; then
   GINKGO_FAIL_FAST="--fail-fast" 
 fi
 
-for TEST_SUITE in integration policy-collection; do
+for TEST_SUITE in policy-collection integration; do
   # Run test suite with reporting
   CGO_ENABLED=0 ginkgo -v ${GINKGO_FAIL_FAST} --junit-report=${TEST_SUITE}.xml --output-dir=test-output test/${TEST_SUITE} -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
 


### PR DESCRIPTION
This might help reduce the flakiness of policy generator test. I found a lot of time
when policy generator test failed, it was the first test case to run.
This might conflict with grc-ui test where it also tried to create new
idp for RBAC test.

Signed-off-by: Yu Cao <ycao@redhat.com>