### PR TITLE
remove results field from policyset status check

### DIFF
--- a/build/patch-dev-images.sh
+++ b/build/patch-dev-images.sh
@@ -11,18 +11,6 @@ DOCKER_URI="quay.io/stolostron"
 echo "* Patching hub cluster to ${VERSION_TAG}"
 oc annotate MultiClusterHub multiclusterhub -n ${acm_installed_namespace} mch-pause=true --overwrite
 
-# Patch the UI on the hub
-COMPONENT="grc-ui"
-LABEL="component=ocm-grcui"
-DEPLOYMENT=$(oc get deployment -l ${LABEL} -n ${acm_installed_namespace} -o=jsonpath='{.items[*].metadata.name}')
-oc patch deployment ${DEPLOYMENT} -n ${acm_installed_namespace} -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${COMPONENT}\",\"imagePullPolicy\":\"Always\",\"image\":\"${DOCKER_URI}/${COMPONENT}:${VERSION_TAG}\"}]}}}}"
-
-# Patch the API on the hub
-COMPONENT="grc-ui-api"
-LABEL="component=ocm-grcuiapi"
-DEPLOYMENT=$(oc get deployment -l ${LABEL} -n ${acm_installed_namespace} -o=jsonpath='{.items[*].metadata.name}')
-oc patch deployment ${DEPLOYMENT} -n ${acm_installed_namespace} -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${COMPONENT}\",\"imagePullPolicy\":\"Always\",\"image\":\"${DOCKER_URI}/${COMPONENT}:${VERSION_TAG}\"}]}}}}"
-
 # Patch the propagator on the hub
 COMPONENT="governance-policy-propagator"
 LABEL="component=ocm-policy-propagator"

--- a/test/e2e/policySet_e2e_test.go
+++ b/test/e2e/policySet_e2e_test.go
@@ -10,32 +10,18 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )
 
 const (
-	testPolicyName          string = "test-policy"
-	testPolicySetName       string = "test-policyset"
-	testPolicySetYaml       string = "../resources/policy_set/test-policyset.yaml"
-	testPolicySetPatchYaml  string = "../resources/policy_set/patch-policy-set.yaml"
-	testedDisablePolicyYaml string = "../resources/policy_set/disable-policy.yaml"
+	testPolicyName             string = "test-policy"
+	testPolicySetName          string = "test-policyset"
+	testPolicySetYaml          string = "../resources/policy_set/test-policyset.yaml"
+	testPolicySetPatchYaml     string = "../resources/policy_set/patch-policy-set.yaml"
+	testUndoPolicySetPatchYaml string = "../resources/policy_set/undo-patch-policy-set.yaml"
+	testedDisablePolicyYaml    string = "../resources/policy_set/disable-policy.yaml"
 )
-
-// update clusterName in checking YAML based clusterNamespace in testing env
-func UpdateClusterName(
-	yamlPlc *unstructured.Unstructured,
-	clusterNamespace string,
-) *unstructured.Unstructured {
-	status := yamlPlc.Object["status"].(map[string]interface{})
-	results := status["results"].([]interface{})
-	clusters := results[0].(map[string]interface{})["clusters"].([]interface{})
-	cluster := clusters[0].(map[string]interface{})
-	cluster["clusterName"] = clusterNamespace
-	cluster["clusterNamespace"] = clusterNamespace
-	return yamlPlc
-}
 
 var _ = Describe("Test policy set", func() {
 	Describe("Create policy, policyset, and placement in ns:"+userNamespace, func() {
@@ -78,9 +64,6 @@ var _ = Describe("Test policy set", func() {
 
 			By("Checking the status of policy set - NonCompliant")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-1.yaml")
-			// set checking yaml clusterName and clusterNamespace by env variable
-			By("Updating the checking YAML clusterName to " + clusterNamespace)
-			yamlPlc = UpdateClusterName(yamlPlc, clusterNamespace)
 
 			Eventually(func() interface{} {
 				rootPlcSet := utils.GetWithTimeout(
@@ -107,8 +90,6 @@ var _ = Describe("Test policy set", func() {
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-2.yaml")
-			By("Updating the checking YAML clusterName to " + clusterNamespace)
-			yamlPlc = UpdateClusterName(yamlPlc, clusterNamespace)
 
 			Eventually(func() interface{} {
 				rootPlcSet := utils.GetWithTimeout(
@@ -117,6 +98,14 @@ var _ = Describe("Test policy set", func() {
 
 				return rootPlcSet.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
+
+			By("Undoing patch with " + testPolicySetPatchYaml)
+			output, err = utils.KubectlWithOutput("apply",
+				"-f", testUndoPolicySetPatchYaml,
+				"-n", userNamespace,
+				"--kubeconfig=../../kubeconfig_hub")
+			By("Creating " + testUndoPolicySetPatchYaml + " result is " + output)
+			Expect(err).To(BeNil())
 		})
 
 		It("Should update to compliant if all its child policy violations have been remediated", func() {
@@ -130,8 +119,6 @@ var _ = Describe("Test policy set", func() {
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-3.yaml")
-			By("Updating the checking YAML clusterName to " + clusterNamespace)
-			yamlPlc = UpdateClusterName(yamlPlc, clusterNamespace)
 
 			Eventually(func() interface{} {
 				rootPlcSet := utils.GetWithTimeout(

--- a/test/resources/policy_set/statuscheck-1.yaml
+++ b/test/resources/policy_set/statuscheck-1.yaml
@@ -10,10 +10,3 @@ status:
   placement:
   - placementBinding: test-policyset-pb
     placementRule: test-policyset-plr
-  results:
-  - clusters:
-    - clusterName: unkown
-      clusterNamespace: unkown
-      compliant: NonCompliant
-    compliant: NonCompliant
-    policy: test-policy

--- a/test/resources/policy_set/statuscheck-2.yaml
+++ b/test/resources/policy_set/statuscheck-2.yaml
@@ -5,17 +5,8 @@ metadata:
 spec:
   policies:
   - test-policy
+  - policyset-does-not-exist
 status:
-  compliant: NonCompliant
   placement:
   - placementBinding: test-policyset-pb
     placementRule: test-policyset-plr
-  results:
-  - clusters:
-    - clusterName: unkown
-      clusterNamespace: unkown
-      compliant: NonCompliant
-    compliant: NonCompliant
-    policy: test-policy
-  - message: policyset-does-not-exist not found
-    policy: policyset-does-not-exist

--- a/test/resources/policy_set/statuscheck-3.yaml
+++ b/test/resources/policy_set/statuscheck-3.yaml
@@ -10,12 +10,3 @@ status:
   placement:
   - placementBinding: test-policyset-pb
     placementRule: test-policyset-plr
-  results:
-  - clusters:
-    - clusterName: unkown
-      clusterNamespace: unkown
-      compliant: Compliant
-    compliant: Compliant
-    policy: test-policy
-  - message: policyset-does-not-exist not found
-    policy: policyset-does-not-exist

--- a/test/resources/policy_set/undo-patch-policy-set.yaml
+++ b/test/resources/policy_set/undo-patch-policy-set.yaml
@@ -5,7 +5,3 @@ metadata:
 spec:
   policies:
   - test-policy
-status:
-  placement:
-  - placementBinding: test-policyset-pb
-    placementRule: test-policyset-plr


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

makes framework test compatible with changes to simplify the policySet status field