### PR TITLE
Create a test for the acm hardening policy set

### DIFF
--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -4,8 +4,10 @@ package common
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os/exec"
 
 	"golang.org/x/crypto/bcrypt"
@@ -36,6 +38,19 @@ type OCPUser struct {
 	ClusterRoleBindings []string
 	Password            string
 	Username            string
+}
+
+// GenerateInsecurePassword is a random password generator from 15-30 bytes. It is insecure
+// since the characters are limited to just hex values (i.e. 1-9,a-f) from the random bytes. An
+// error is returned if the random bytes cannot be read.
+func GenerateInsecurePassword() (string, error) {
+	// A password ranging from 15-30 bytes
+	pwSize := rand.Intn(15) + 15
+	bytes := make([]byte, pwSize)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
 }
 
 // GetKubeConfig will generate a kubeconfig file based on an OpenShift user. The path of the

--- a/test/resources/policy_generator/acm-hardening_subscription.yaml
+++ b/test/resources/policy_generator/acm-hardening_subscription.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+spec:
+  clusterSet: default
+---
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: acm-hardening
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - acm-hardening
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: acm-hardening
+spec:
+  type: Git
+  pathname: https://github.com/stolostron/policy-collection.git
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/git-branch: main
+    apps.open-cluster-management.io/git-path: policygenerator/policy-sets/stable/acm-hardening
+    apps.open-cluster-management.io/reconcile-option: merge
+  labels:
+    app: acm-hardening
+  name: acm-hardening-subscription
+spec:
+  channel: policies/acm-hardening
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: acm-hardening-placement
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  labels:
+    app: acm-hardening
+  name: acm-hardening-placement
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: In
+        values:
+          - "true"


### PR DESCRIPTION
The acm hardening policy set has been moved to a stable directory.
This is a test that will help make sure it continues to have some
validation.

Refs:
 - https://github.com/stolostron/backlog/issues/20337

Signed-off-by: Gus Parvin <gparvin@redhat.com>