### PR TITLE
Add test for `policy-scc.yaml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,13 +304,6 @@ integration-test:
 		$(GOPATH)/bin/ginkgo -v $(TEST_ARGS) --fail-fast --focus-file=$(TEST_FILE) test/integration;\
 	fi
 
-policy-collection-test:
-	@if [ -z "$(TEST_FILE)" ]; then\
-		$(GOPATH)/bin/ginkgo -v $(TEST_ARGS) --fail-fast --label-filter="policy-collection" test/integration;\
-	else\
-		$(GOPATH)/bin/ginkgo -v $(TEST_ARGS) --fail-fast --focus-file=$(TEST_FILE) test/integration;\
-	fi
-
 # go-get-tool will 'go get' any package $2 and install it to $1.
 define go-get-tool
 @[ -f $(1) ] || { \

--- a/doc/development.md
+++ b/doc/development.md
@@ -66,15 +66,8 @@ export TEST_FILE=<filename_test.go>
 make e2e-test
 ```
 
-### Integration
+### Integration (including Policy Collection)
 
 ```shell
 make integration-test
-```
-
-
-### Policy Collection
-
-```shell
-make policy-collection-test
 ```

--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -22,6 +22,7 @@ var (
 	GvrComplianceScan        = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancescans"}
 	GvrComplianceSuite       = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancesuites"}
 	GvrComplianceCheckResult = schema.GroupVersionResource{Group: "compliance.openshift.io", Version: "v1alpha1", Resource: "compliancecheckresults"}
+	GvrSCC                   = schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"}
 	GvrRoute                 = schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}
 	GvrOAuth                 = schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "oauths"}
 	GvrUser                  = schema.GroupVersionResource{Group: "user.openshift.io", Version: "v1", Resource: "users"}

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -25,16 +25,15 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	policyCertificateName   = "policy-certificate"
-	policyCertificateURL    = policyCollectSCURL + policyCertificateName + ".yaml"
-	expiredCertSecretName   = "expired-cert"
-	policyCertificateNSName = "policy-certificate"
-)
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-certificate policy", Label("policy-collection", "stable", "BVT"), func() {
 
-var policyCertLabel = Label("policy-collection", "stable", "BVT")
+	const (
+		policyCertificateName   = "policy-certificate"
+		policyCertificateURL    = policyCollectSCURL + policyCertificateName + ".yaml"
+		expiredCertSecretName   = "expired-cert"
+		policyCertificateNSName = "policy-certificate"
+	)
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the "+policyCertificateName+" policy", policyCertLabel, func() {
 	It("stable/"+policyCertificateName+" should be created on the Hub", func() {
 		By("Creating the policy on the Hub")
 		_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -17,16 +17,15 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	policyEtcdEncryptionName = "policy-etcdencryption"
-	policyEtcdEncryptionURL  = policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
-	apiSeverName             = "cluster"
-	configPolicyName         = "enable-etcd-encryption"
-)
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Label("policy-collection", "stable"), func() {
 
-var etcdEncLabels = Label("policy-collection", "stable")
+	const (
+		policyEtcdEncryptionName = "policy-etcdencryption"
+		policyEtcdEncryptionURL  = policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
+		apiSeverName             = "cluster"
+		configPolicyName         = "enable-etcd-encryption"
+	)
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the "+policyEtcdEncryptionName+" policy", etcdEncLabels, func() {
 	It("stable/"+policyEtcdEncryptionName+" should be created on the Hub", func() {
 		By("Creating the policy on the Hub")
 		_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -14,14 +14,15 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	iamPolicyName             = "policy-limitclusteradmin"
-	iamPolicyURL              = policyCollectACURL + iamPolicyName + ".yaml"
-	iamPolicyManagedNamespace = "iam-policy-test"
-)
-
 // Note that these tests must be run on OpenShift since the tests create an OpenShift group
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the stable IAM policy", Label("policy-collection", "stable", "BVT"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin policy", Label("policy-collection", "stable", "BVT"), func() {
+
+	const (
+		iamPolicyName             = "policy-limitclusteradmin"
+		iamPolicyURL              = policyCollectACURL + iamPolicyName + ".yaml"
+		iamPolicyManagedNamespace = "iam-policy-test"
+	)
+
 	var getIAMComplianceState func() interface{}
 	BeforeEach(func() {
 		// Assign this here to avoid using nil pointers as arguments

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -17,23 +17,25 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	propagatorMetricsSelector = "component=ocm-policy-propagator"
-	ocmNS                     = "open-cluster-management"
-	metricName                = "policy_governance_info"
-	saName                    = "grc-framework-sa"
-	roleBindingName           = "grc-framework-role-binding"
-	compliantPolicyYaml       = "../resources/policy_info_metric/compliant.yaml"
-	compliantPolicyName       = "policy-metric-compliant"
-	noncompliantPolicyYaml    = "../resources/policy_info_metric/noncompliant.yaml"
-	noncompliantPolicyName    = "policy-metric-noncompliant"
-)
-
-var propagatorMetricsURL string
-
-var metricToken string
-
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", Label("BVT"), func() {
+
+	const (
+		propagatorMetricsSelector = "component=ocm-policy-propagator"
+		ocmNS                     = "open-cluster-management"
+		metricName                = "policy_governance_info"
+		saName                    = "grc-framework-sa"
+		roleBindingName           = "grc-framework-role-binding"
+		compliantPolicyYaml       = "../resources/policy_info_metric/compliant.yaml"
+		compliantPolicyName       = "policy-metric-compliant"
+		noncompliantPolicyYaml    = "../resources/policy_info_metric/noncompliant.yaml"
+		noncompliantPolicyName    = "policy-metric-noncompliant"
+	)
+
+	var (
+		metricToken          string
+		propagatorMetricsURL string
+	)
+
 	It("Sets up the metrics service endpoint for tests", func() {
 		By("Ensuring the metrics service exists")
 		svcList, err := clientHub.CoreV1().Services(ocmNS).List(context.TODO(), metav1.ListOptions{LabelSelector: propagatorMetricsSelector})

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -17,16 +17,15 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	policyLimitMemoryName   = "policy-limitmemory"
-	policyLimitMemoryURL    = policyCollectSCURL + policyLimitMemoryName + ".yaml"
-	policyLimitMemoryNSName = "policy-limitmemory"
-	limitRangeName          = "mem-limit-range"
-)
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy", Label("policy-collection", "stable"), func() {
 
-var limitMemoryLabel = Label("policy-collection", "stable")
+	const (
+		policyLimitMemoryName   = "policy-limitmemory"
+		policyLimitMemoryURL    = policyCollectSCURL + policyLimitMemoryName + ".yaml"
+		policyLimitMemoryNSName = "policy-limitmemory"
+		limitRangeName          = "mem-limit-range"
+	)
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the "+policyLimitMemoryName+" policy", limitMemoryLabel, func() {
 	It("stable/"+policyLimitMemoryName+" should be created on the Hub", func() {
 		By("Creating the policy on the Hub")
 		_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const policyNamespaceName = "policy-namespace"
-const policyNamespaceURL = policyCollectCMURL + policyNamespaceName + ".yaml"
-
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy", Label("policy-collection", "stable"), func() {
+
+	const (
+		policyNamespaceName = "policy-namespace"
+		policyNamespaceURL  = policyCollectCMURL + policyNamespaceName + ".yaml"
+	)
+
 	It("stable/"+policyNamespaceName+" should be created on the Hub", func() {
 		By("Creating policy on hub")
 		_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -17,21 +17,26 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	insightsClientSelector       = "component=insights-client"
-	insightsMetricsSelector      = "component=insights-metrics"
-	insightsMetricName           = "policyreport_info"
-	noncompliantPolicyYamlReport = "../resources/policy_report_metric/noncompliant.yaml"
-	noncompliantPolicyNameReport = "policyreport-metric-noncompliant"
-	compliantPolicyYamlReport    = "../resources/policy_report_metric/compliant.yaml"
-	compliantPolicyNameReport    = "policyreport-metric-noncompliant"
-)
-
-var insightsMetricsURL string
-
-var insightsToken string
-
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Label("BVT"), func() {
+
+	const (
+		ocmNS                        = "open-cluster-management"
+		saName                       = "grc-framework-sa"
+		roleBindingName              = "grc-framework-role-binding"
+		insightsClientSelector       = "component=insights-client"
+		insightsMetricsSelector      = "component=insights-metrics"
+		insightsMetricName           = "policyreport_info"
+		noncompliantPolicyYamlReport = "../resources/policy_report_metric/noncompliant.yaml"
+		noncompliantPolicyNameReport = "policyreport-metric-noncompliant"
+		compliantPolicyYamlReport    = "../resources/policy_report_metric/compliant.yaml"
+		compliantPolicyNameReport    = "policyreport-metric-noncompliant"
+	)
+
+	var (
+		insightsMetricsURL string
+		insightsToken      string
+	)
+
 	It("Sets up the metrics service endpoint for tests", func() {
 		By("Setting the insights client to poll every minute")
 		insightsClient, err := common.OcHub("get", "deployments", "-n", ocmNS, "-l", insightsClientSelector, "-o", "name")

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	"github.com/stolostron/governance-policy-propagator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
+)
+
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Label("policy-collection", "stable"), func() {
+
+	const (
+		rootPolicyName   = "policy-securitycontextconstraints"
+		rootPolicyURL    = policyCollectSCURL + "policy-scc.yaml"
+		rootPolicyNSName = "policy-scc"
+		targetName       = "restricted"
+		targetKind       = "scc"
+	)
+
+	var (
+		targetGVR = common.GvrSCC
+	)
+
+	It("stable/"+rootPolicyName+" should be created on the Hub", func() {
+		By("Creating the policy on the Hub")
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", rootPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
+		)
+		Expect(err).To(BeNil())
+
+		By("Patching placement rule")
+		err = common.PatchPlacementRule(
+			userNamespace, "placement-"+rootPolicyName, clusterNamespace, kubeconfigHub,
+		)
+		Expect(err).To(BeNil())
+
+		By("Checking that " + rootPolicyName + " exists on the Hub cluster")
+		rootPolicy := utils.GetWithTimeout(
+			clientHubDynamic, common.GvrPolicy, rootPolicyName, userNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(rootPolicy).NotTo(BeNil())
+	})
+
+	It("stable/"+rootPolicyName+" should be created on managed cluster", func() {
+		By("Checking the policy on managed cluster in ns " + clusterNamespace)
+		managedPolicy := utils.GetWithTimeout(
+			clientManagedDynamic,
+			common.GvrPolicy,
+			userNamespace+"."+rootPolicyName,
+			clusterNamespace,
+			true,
+			defaultTimeoutSeconds,
+		)
+		Expect(managedPolicy).NotTo(BeNil())
+	})
+
+	// This is a special case because it specifies a manifest that by default is on an Openshift cluster
+	It("stable/"+rootPolicyName+" should be Compliant", func() {
+		By("Checking if the status of the root policy is Compliant")
+		Eventually(
+			common.GetComplianceState(clientHubDynamic, userNamespace, rootPolicyName, clusterNamespace),
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(Equal(policiesv1.Compliant))
+	})
+
+	It("Enforcing stable/"+rootPolicyName, func() {
+		By("Patching remediationAction = enforce on the root policy")
+		_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Patch(
+			context.TODO(),
+			rootPolicyName,
+			k8stypes.JSONPatchType,
+			[]byte(`[{"op": "replace", "path": "/spec/remediationAction", "value": "enforce"}]`),
+			metav1.PatchOptions{},
+		)
+		Expect(err).To(BeNil())
+	})
+
+	It("stable/"+rootPolicyName+" should be Compliant", func() {
+		By("Checking if the status of the root policy is Compliant")
+		Eventually(
+			common.GetComplianceState(clientHubDynamic, userNamespace, rootPolicyName, clusterNamespace),
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(Equal(policiesv1.Compliant))
+	})
+
+	It("The "+targetKind+" should exist", func() {
+		By("Checking the " + targetKind)
+		Eventually(
+			func() error {
+				_, err := clientManagedDynamic.Resource(targetGVR).Get(
+					context.TODO(), targetName, metav1.GetOptions{},
+				)
+
+				return err
+			},
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(BeNil())
+	})
+
+	It("Cleans up", func() {
+		_, err := utils.KubectlWithOutput(
+			"delete", "-f", rootPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
+		)
+		Expect(err).To(BeNil())
+	})
+})

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -15,16 +15,17 @@ import (
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	testPolicyName             string = "test-policy"
-	testPolicySetName          string = "test-policyset"
-	testPolicySetYaml          string = "../resources/policy_set/test-policyset.yaml"
-	testPolicySetPatchYaml     string = "../resources/policy_set/patch-policy-set.yaml"
-	testUndoPolicySetPatchYaml string = "../resources/policy_set/undo-patch-policy-set.yaml"
-	testedDisablePolicyYaml    string = "../resources/policy_set/disable-policy.yaml"
-)
-
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Label("BVT"), func() {
+
+	const (
+		testPolicyName             string = "test-policy"
+		testPolicySetName          string = "test-policyset"
+		testPolicySetYaml          string = "../resources/policy_set/test-policyset.yaml"
+		testPolicySetPatchYaml     string = "../resources/policy_set/patch-policy-set.yaml"
+		testUndoPolicySetPatchYaml string = "../resources/policy_set/undo-patch-policy-set.yaml"
+		testedDisablePolicyYaml    string = "../resources/policy_set/disable-policy.yaml"
+	)
+
 	Describe("Create policy, policyset, and placement in ns:"+userNamespace, func() {
 		It("Should create and process policy and policyset", func() {
 			By("Creating " + testPolicySetYaml)


### PR DESCRIPTION
Notes:
- Reduces package-level variables to prevent collisions and allow for similarly named variables in each test file
- Adds test for `policy-scc.yaml`
  - Along with the package-level variable reduction, with this test file I attempted to establish a boilerplate test format where a new test for a new kind could be written with minimal updates (primarily to the variable declarations at the top) and then built upon

Addresses:
- https://github.com/stolostron/backlog/issues/20846