### PR TITLE
Run etcd-encryption at last

### DIFF
--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -31,29 +31,33 @@ $DIR/patch-cluster-prow.sh
 cp ${HUB_KUBE} $DIR/../kubeconfig_hub
 cp ${MANAGED_KUBE} $DIR/../kubeconfig_managed
 
-if [[ -z ${GINKGO_LABEL_FILTER} ]]; then 
-  echo "* No GINKGO_LABEL_FILTER set"
-else
-  GINKGO_LABEL_FILTER="--label-filter=${GINKGO_LABEL_FILTER}"
-  echo "* Using GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER}"
-fi
-
 echo "===== E2E Test ====="
 echo "* Launching grc policy framework test"
-# Run test suite with reporting
-CGO_ENABLED=0 ginkgo -v --no-color --fail-fast ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+if [[ -z ${GINKGO_LABEL_FILTER} ]]; then 
+  echo "* No GINKGO_LABEL_FILTER set"
+  LABEL_FILTERS=("!etcd" "etcd")
+else
+  echo "* Using GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER}"
+  LABEL_FILTERS=${GINKGO_LABEL_FILTER}
+fi
+
+for LABEL_FILTER in ${LABEL_FILTERS[@]}; do
+  CGO_ENABLED=0 ginkgo -v --no-color --fail-fast --label-filter="$LABEL_FILTER" --junit-report=integration-$LABEL_FILTER.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+
+  # Collect exit code if it's an error
+  if [[ "${EXIT_CODE}" != "0" ]]; then
+    ERROR_CODE=${EXIT_CODE}
+  fi
+done
 
 # Remove Ginkgo phases from report to prevent corrupting bracketed metadata
-if [ -f test-output/integration.xml ]; then
-  sed -i 's/\[It\] *//g' test-output/integration.xml
-  sed -i 's/\[BeforeSuite\]/GRC: [P1][Sev1][policy-grc] BeforeSuite/g' test-output/integration.xml
-  sed -i 's/\[AfterSuite\]/GRC: [P1][Sev1][policy-grc] AfterSuite/g' test-output/integration.xml
-fi
-
-# Collect exit code if it's an error
-if [[ "${EXIT_CODE}" != "0" ]]; then
-  ERROR_CODE=${EXIT_CODE}
-fi
+REPORTS=`find test-output/*.xml`
+for report in $REPORTS; do  
+  echo "* Updating report $report"
+  sed -i 's/\[It\] *//g' $report
+  sed -i 's/\[BeforeSuite\]/GRC: [P1][Sev1][policy-grc] BeforeSuite/g' $report
+  sed -i 's/\[AfterSuite\]/GRC: [P1][Sev1][policy-grc] AfterSuite/g' $report
+done
 
 if [[ -n "${ERROR_CODE}" ]]; then
     echo "* Detected test failure. Collecting debug logs..."

--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -8,27 +8,33 @@ if [[ ${FAIL_FAST} == "true" ]]; then
   GINKGO_FAIL_FAST="--fail-fast" 
 fi
 
+echo "===== E2E Test ====="
+echo "* Launching grc policy framework test"
 if [[ -z ${GINKGO_LABEL_FILTER} ]]; then 
   echo "* No GINKGO_LABEL_FILTER set"
+  LABEL_FILTERS=("!etcd" "etcd")
 else
-  GINKGO_LABEL_FILTER="--label-filter=${GINKGO_LABEL_FILTER}"
   echo "* Using GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER}"
+  LABEL_FILTERS=${GINKGO_LABEL_FILTER}
 fi
 
-# Run test suite with reporting
-CGO_ENABLED=0 ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+for LABEL_FILTER in ${LABEL_FILTERS[@]}; do
+  CGO_ENABLED=0 ginkgo -v --no-color --fail-fast --label-filter="$LABEL_FILTER" --junit-report=integration-$LABEL_FILTER.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
 
-# Remove Gingko phases from report to prevent corrupting bracketed metadata
-if [ -f test-output/integration.xml ]; then
-  sed -i 's/\[It\] *//g' test-output/integration.xml
-  sed -i 's/\[BeforeSuite\]/GRC: [P1][Sev1][policy-grc] BeforeSuite/g' test-output/integration.xml
-  sed -i 's/\[AfterSuite\]/GRC: [P1][Sev1][policy-grc] AfterSuite/g' test-output/integration.xml
-fi
+  # Collect exit code if it's an error
+  if [[ "${EXIT_CODE}" != "0" ]]; then
+    ERROR_CODE=${EXIT_CODE}
+  fi
+done
 
-# Collect exit code if it's an error
-if [[ "${EXIT_CODE}" != "0" ]]; then
-  ERROR_CODE=${EXIT_CODE}
-fi
+# Remove Ginkgo phases from report to prevent corrupting bracketed metadata
+REPORTS=`find test-output/*.xml`
+for report in $REPORTS; do  
+  echo "* Updating report $report"
+  sed -i 's/\[It\] *//g' $report
+  sed -i 's/\[BeforeSuite\]/GRC: [P1][Sev1][policy-grc] BeforeSuite/g' $report
+  sed -i 's/\[AfterSuite\]/GRC: [P1][Sev1][policy-grc] AfterSuite/g' $report
+done
 
 if [[ -n "${ERROR_CODE}" ]]; then
     echo "* Detected test failure. Collecting debug logs..."

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Label("policy-collection", "stable", "etcd"), func() {
 
 	const (
 		policyEtcdEncryptionName = "policy-etcdencryption"


### PR DESCRIPTION
If no `GINKGO_LABEL_FILTER` is set, automatically separate the test cases into two groups.

Side effect: It will generate a lot of skipped test cases due to the change and will affect the reporting in canary.

We don't need this change if canary test cases are not affected by etcd encryption.

Signed-off-by: Yu Cao <ycao@redhat.com>