### PR TITLE
Increate timeout for finding the vulnerable images

### DIFF
--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -167,7 +167,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 				}
 				return ""
 			},
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(Equal(string(policiesv1.NonCompliant)))
 	})


### PR DESCRIPTION
I see things taking a lot longer in the canary for downstream.

```
STEP: Checking if the status of the subscription config policy is Compliant 04/04/22 10:00:33.838
STEP: Checking if the status of the CSV config policy is Compliant 04/04/22 10:00:43.886
STEP: Checking if the status of the IMV config policy is NonCompliant 04/04/22 10:01:01.986
------------------------------
• [FAILED] [88.149 seconds]
GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln policy [policy-collection, stable, BVT]
/go/src/github.com/stolostron/governance-policy-framework/test/integration/policy_imagemanifest_test.go:20
  [It] stable/policy-imagemanifestvuln should detect imageManifestVulns
  /go/src/github.com/stolostron/governance-policy-framework/test/integration/policy_imagemanifest_test.go:107
  Begin Captured GinkgoWriter Output >>
    STEP: Checking if the status of the subscription config policy is Compliant 04/04/22 10:00:33.838
    STEP: Checking if the status of the CSV config policy is Compliant 04/04/22 10:00:43.886
    STEP: Checking if the status of the IMV config policy is NonCompliant 04/04/22 10:01:01.986
  << End Captured GinkgoWriter Output
  Timed out after 60.000s.

  Expected
      <string>: Compliant
  to equal
      <string>: NonCompliant
```

I do not see any problems with the GRC code or the testcase right now.
It just looks like the image scanning took longer than manual runs.

Refs:
 - https://github.com/stolostron/backlog/issues/21372

Signed-off-by: Gus Parvin <gparvin@redhat.com>