### PR TITLE
PlacementRule is making calls to PlacementDecisions

### DIFF
--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -105,6 +105,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated P
 					Resources:     []string{"managedclustersets/bind"},
 					ResourceNames: []string{"default"},
 				},
+				{
+					APIGroups: []string{"cluster.open-cluster-management.io"},
+					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{"placementdecisions"},
+				},
 			},
 		}
 


### PR DESCRIPTION
There are some rbac failures in the placementrules controller that
shows placementdecisions verbs get, list, watch are needed for the
user access of placement.  This may be needed in the tests that
use placementrule too.

Refs:
 - https://github.com/stolostron/backlog/issues/21455

Signed-off-by: Gus Parvin <gparvin@redhat.com>