### PR TITLE
Downstream builds are running with no vulnerable images

### DIFF
--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -24,8 +24,14 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 	const operatorNS = "openshift-operators"
 
 	It("stable/"+policyIMVName+" should be created on the Hub", func() {
-		By("Creating the policy on the Hub")
+		By("Creating deployment that has an image with vulnerabilities")
 		_, err := utils.KubectlWithOutput(
+			"apply", "-f", "../resources/image-vulnerabilities/vulnerable-pod.yaml", "--kubeconfig="+kubeconfigHub,
+		)
+		Expect(err).To(BeNil())
+
+		By("Creating the policy on the Hub")
+		_, err = utils.KubectlWithOutput(
 			"apply", "-f", policyIMVURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)
 		Expect(err).To(BeNil())
@@ -208,6 +214,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 
 		_, err = utils.KubectlWithOutput(
 			"delete", "crd", "imagemanifestvulns.secscan.quay.redhat.com", "--kubeconfig="+kubeconfigManaged,
+		)
+		Expect(err).To(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"delete", "deployment", "-n", "default", "nginx-deployment", "--kubeconfig="+kubeconfigHub,
 		)
 		Expect(err).To(BeNil())
 	})

--- a/test/resources/image-vulnerabilities/vulnerable-pod.yaml
+++ b/test/resources/image-vulnerabilities/vulnerable-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: quay.io/bitnami/nginx:1.20
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Our container security operator test assumes we'll have a vulnerable
image somewhere.  That's not the case for current downstream 2.5
builds.  Adding a vulnerable image as part of the test case.

Refs:
 - https://github.com/stolostron/backlog/issues/21459

Signed-off-by: Gus Parvin <gparvin@redhat.com>