### PR TITLE
Container image scanning can take a lot of time, increase timeout

### DIFF
--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -173,7 +173,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 				}
 				return ""
 			},
-			defaultTimeoutSeconds*4,
+			defaultTimeoutSeconds*12,
 			1,
 		).Should(Equal(string(policiesv1.NonCompliant)))
 	})


### PR DESCRIPTION
In downstream builds there were few images that the CSO could scan,
so finding the one with the vulnerability shouldn't take too long. In
upstream there are lots of images that don't have vulnerabilities, so
finding the one with vulnerabilities can take much longer.  My local
testing was finding vulnerabilities within about 3 minutes, so it's
certainly possible the canary test is consistently taking longer than
the 2 minutes allotted.  Logs haven't been useful to identify a root
cause because tests clean up.  Theory on failure is from local tests

Refs:
 - https://github.com/stolostron/backlog/issues/21734

Signed-off-by: Gus Parvin <gparvin@redhat.com>