### PR TITLE
Add some debug info to try to analyze canary issue

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -150,7 +150,15 @@ func OcManaged(args ...string) (string, error) {
 }
 
 func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) error {
-	_, err := utils.KubectlWithOutput(
+	// Debug the kubeconfig file which in some cases gets corrupted with the grc e2e user
+	contents, err := os.ReadFile(kubeconfigHub)
+	if err != nil {
+		fmt.Printf("DEBUG: hubkubeconfig read error: %s\n", kubeconfigHub)
+	} else {
+		fmt.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:1024])
+	}
+
+	_, err = utils.KubectlWithOutput(
 		"patch",
 		"-n",
 		namespace,

--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"os/exec"
 	"time"
 
@@ -86,6 +87,7 @@ func GetKubeConfig(server, username, password string) (string, error) {
 		"--insecure-skip-tls-verify=true",
 	).CombinedOutput()
 	if err != nil {
+		os.Remove(f.Name())
 		return "", fmt.Errorf("failed to login: %s", output)
 	}
 

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -47,6 +47,14 @@ func cleanup(namespace string, secret string, user common.OCPUser) {
 	if !k8serrors.IsNotFound(err) {
 		Expect(err).Should(BeNil())
 	}
+
+	// Debug the kubeconfig file which in some cases gets corrupted with the grc e2e user
+	contents, err := os.ReadFile(common.KubeconfigHub)
+	if err != nil {
+		GinkgoWriter.Printf("DEBUG: hubkubeconfig read error: %s\n", common.KubeconfigHub)
+	} else {
+		GinkgoWriter.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:1024])
+	}
 }
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated PolicySet in an App subscription", Label("policy-collection", "stable"), func() {
@@ -157,7 +165,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated P
 				return err
 			},
 			fiveMinutes,
-			1,
+			10,
 		).Should(BeNil())
 		// Delete the kubeconfig file after the test.
 		defer func() { os.Remove(kubeconfigSubAdmin) }()


### PR DESCRIPTION
Are we corrupting the hub kubeconfig?  Printing it out to find out.
The one we create is usually less than 900 bytes so I think if we
overwrite the hub kubeconfig with the e2e one it will be obvious from
the trace -- but this won't necessarily help us know why.

Refs:
 - https://github.com/stolostron/backlog/issues/22014

Signed-off-by: Gus Parvin <gparvin@redhat.com>