### PR TITLE
Backport owners file update to the 2.3 release

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,14 +4,9 @@ approvers:
 - dhaiducek
 - gparvin
 - willkutler
-- ycao56
-
-
 reviewers:
 - ChunxiAlexLuo
 - ckandag
 - dhaiducek
 - gparvin
 - willkutler
-- ycao56
-


### PR DESCRIPTION
Manual backport of owners file due to cherry pick merge conflict

Signed-off-by: Gus Parvin <gparvin@redhat.com>