### PR TITLE
Failure when the kubeconfig is smaller than my slice index

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -155,7 +155,11 @@ func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) er
 	if err != nil {
 		fmt.Printf("DEBUG: hubkubeconfig read error: %s\n", kubeconfigHub)
 	} else {
-		fmt.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:1024])
+		length := len(contents)
+		if length > 1024 {
+			length = 1024
+		}
+		fmt.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:length])
 	}
 
 	_, err = utils.KubectlWithOutput(

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -53,7 +53,11 @@ func cleanup(namespace string, secret string, user common.OCPUser) {
 	if err != nil {
 		GinkgoWriter.Printf("DEBUG: hubkubeconfig read error: %s\n", common.KubeconfigHub)
 	} else {
-		GinkgoWriter.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:1024])
+		length := len(contents)
+		if length > 1024 {
+			length = 1024
+		}
+		GinkgoWriter.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:length])
 	}
 }
 


### PR DESCRIPTION
My kubeconfigs I thought were smaller than 1024, but I guess they only
ran against bigger ones in testing.

Refs:
- see CI failure in grc repo

Signed-off-by: Gus Parvin <gparvin@redhat.com>