### PR TITLE
Use the new Policy Propagator module name in imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ kind-deploy-olm:
 	@echo installing OLM on managed
 	export KUBECONFIG=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$(OLM_VERSION)/install.sh -o install.sh
+	# Workaround for https://github.com/operator-framework/operator-lifecycle-manager/issues/2767
+	sed -i 's_kubectl apply -f "$${url}/crds.yaml"_kubectl create -f "$${url}/crds.yaml"_' install.sh
 	chmod +x install.sh
 	./install.sh $(OLM_VERSION)
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.17
 require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
-	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
+	open-cluster-management.io/governance-policy-propagator v0.0.0
 )
 
 require (
@@ -42,7 +42,7 @@ require (
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
-	open-cluster-management.io/api v0.6.0 // indirect
+	open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5 // indirect
 	open-cluster-management.io/multicloud-operators-subscription v0.6.0 // indirect
 	sigs.k8s.io/controller-runtime v0.11.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
@@ -50,4 +50,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace k8s.io/client-go => k8s.io/client-go v0.23.3
+replace (
+	k8s.io/client-go => k8s.io/client-go v0.23.3
+	open-cluster-management.io/governance-policy-propagator => github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee
+)

--- a/go.sum
+++ b/go.sum
@@ -898,9 +898,10 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
-github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38 h1:a3mDbBUE0eVXdzv0IIsz6/48F7Ru6LxwPduryJU7UXQ=
-github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38/go.mod h1:8lcjUP24z9gIZ1nCydZyOxIqz6CpVDtVt5KPAlsi+tY=
+github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee h1:LgW1jklD9sFTs2APhyUMeFf/2TMI+SC+uJfCSZ/mtDs=
+github.com/stolostron/governance-policy-propagator v0.0.0-20220427184903-387712d230ee/go.mod h1:yMzjFPXvRoNHSY3ggD9d8ffukUVDGCHhMxAvj3q5EEE=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
@@ -1709,8 +1710,8 @@ open-cluster-management.io/addon-framework v0.0.0-20210624140015-b26f9964526c/go
 open-cluster-management.io/api v0.0.0-20210607023841-cd164385e2bb/go.mod h1:9qiA5h/8kvPQnJEOlAPHVjRO9a1jCmDhGzvgMBvXEaE=
 open-cluster-management.io/api v0.0.0-20210629235044-d779373b7f7d/go.mod h1:9qiA5h/8kvPQnJEOlAPHVjRO9a1jCmDhGzvgMBvXEaE=
 open-cluster-management.io/api v0.5.1-0.20211109002058-9676c7a1e606/go.mod h1:9qiA5h/8kvPQnJEOlAPHVjRO9a1jCmDhGzvgMBvXEaE=
-open-cluster-management.io/api v0.6.0 h1:PzR1G/d9YmwL742lgJgFgsEJs6i8Zg05pdIhK/iLZV4=
-open-cluster-management.io/api v0.6.0/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
+open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5 h1:0Zn4+5qfXTHCjoa7pg8+fI/Gebr4bQDHWR+d1XPa47c=
+open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
 open-cluster-management.io/multicloud-operators-channel v0.5.1-0.20211122200432-da1610291798/go.mod h1:ELKJ1LHadEYbYHEeWrZXC8zAHrzXzzKJRtp/7D1WlmU=
 open-cluster-management.io/multicloud-operators-subscription v0.6.0 h1:0WKplR0cLBXy+qkqt/Scd3eTcEOno0OvzAXzAhe9nLQ=
 open-cluster-management.io/multicloud-operators-subscription v0.6.0/go.mod h1:riyPTC500zbKxVw3KT91yKNlpPxTdWDnUpOQ9xcLmXc=

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -12,14 +12,14 @@ import (
 	"strings"
 
 	"github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 var (

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -8,8 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -8,8 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -9,12 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/e2e/hub_templates_encryption_test.go
+++ b/test/e2e/hub_templates_encryption_test.go
@@ -13,11 +13,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-framework/test/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("Test Hub Template Encryption", func() {

--- a/test/e2e/iam_policy_test.go
+++ b/test/e2e/iam_policy_test.go
@@ -8,8 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/e2e/policySet_e2e_test.go
+++ b/test/e2e/policySet_e2e_test.go
@@ -8,8 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 )
 
 const (

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -16,17 +16,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-certificate policy", Label("policy-collection", "stable", "BVT"), func() {
-
 	const (
 		policyCertificateName   = "policy-certificate"
 		policyCertificateURL    = policyCollectSCURL + policyCertificateName + ".yaml"

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -10,10 +10,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
@@ -34,6 +34,7 @@ func isOCP46andAbove() bool {
 	// should be ocp 4.6 and above
 	return true
 }
+
 func complianceScanTest(scanPolicyName string, scanPolicyUrl string, scanName string) {
 	It("stable/"+scanPolicyName+" should be created on hub", func() {
 		By("Creating policy on hub")

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -8,17 +8,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Label("policy-collection", "stable", "etcd"), func() {
-
 	const (
 		policyEtcdEncryptionName = "policy-etcdencryption"
 		policyEtcdEncryptionURL  = policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
@@ -93,7 +92,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption pol
 				policy, err := clientManagedDynamic.Resource(common.GvrConfigurationPolicy).Namespace(clusterNamespace).Get(
 					context.TODO(), configPolicyName, metav1.GetOptions{},
 				)
-
 				if err != nil {
 					return ""
 				}

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -10,9 +10,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -10,10 +10,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_hub_templates_21440_test.go
+++ b/test/integration/policy_hub_templates_21440_test.go
@@ -8,11 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
@@ -94,7 +94,6 @@ var _ = Describe(
 					configMap, err := clientManaged.CoreV1().ConfigMaps("default").Get(
 						ctx, configMapCopyName, metav1.GetOptions{},
 					)
-
 					if err != nil {
 						return ""
 					}

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -5,18 +5,17 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 // Note that these tests must be run on OpenShift since the tests create an OpenShift group
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin policy", Label("policy-collection", "stable", "BVT"), func() {
-
 	const (
 		iamPolicyName             = "policy-limitclusteradmin"
 		iamPolicyURL              = policyCollectACURL + iamPolicyName + ".yaml"

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -9,10 +9,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -10,15 +10,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", Label("BVT"), func() {
-
 	const (
 		propagatorMetricsSelector = "component=ocm-policy-propagator"
 		ocmNS                     = "open-cluster-management"

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -8,17 +8,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy", Label("policy-collection", "stable"), func() {
-
 	const (
 		policyLimitMemoryName   = "policy-limitmemory"
 		policyLimitMemoryURL    = policyCollectSCURL + policyLimitMemoryName + ".yaml"

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -8,16 +8,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy", Label("policy-collection", "stable"), func() {
-
 	const (
 		policyNamespaceName = "policy-namespace"
 		policyNamespaceURL  = policyCollectCMURL + policyNamespaceName + ".yaml"

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -8,11 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -8,10 +8,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -10,15 +10,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Label("BVT"), func() {
-
 	const (
 		ocmNS                        = "open-cluster-management"
 		saName                       = "grc-framework-sa"

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -8,11 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -8,11 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -8,16 +8,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Label("policy-collection", "stable"), func() {
-
 	const (
 		rootPolicyName   = "policy-securitycontextconstraints"
 		rootPolicyURL    = policyCollectSCURL + "policy-scc.yaml"
@@ -26,9 +25,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Label
 		targetKind       = "scc"
 	)
 
-	var (
-		targetGVR = common.GvrSCC
-	)
+	targetGVR := common.GvrSCC
 
 	It("stable/"+rootPolicyName+" should be created on the Hub", func() {
 		By("Creating the policy on the Hub")

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -8,15 +8,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stolostron/governance-policy-propagator/test/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Label("BVT"), func() {
-
 	const (
 		testPolicyName             string = "test-policy"
 		testPolicySetName          string = "test-policyset"


### PR DESCRIPTION
This also adds in changes from running `make fmt`.

Related:
https://github.com/stolostron/backlog/issues/21790