### PR TITLE
Remove debug logging

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -150,19 +150,7 @@ func OcManaged(args ...string) (string, error) {
 }
 
 func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) error {
-	// Debug the kubeconfig file which in some cases gets corrupted with the grc e2e user
-	contents, err := os.ReadFile(kubeconfigHub)
-	if err != nil {
-		fmt.Printf("DEBUG: hubkubeconfig read error: %s\n", kubeconfigHub)
-	} else {
-		length := len(contents)
-		if length > 1024 {
-			length = 1024
-		}
-		fmt.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:length])
-	}
-
-	_, err = utils.KubectlWithOutput(
+	_, err := utils.KubectlWithOutput(
 		"patch",
 		"-n",
 		namespace,

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -47,18 +47,6 @@ func cleanup(namespace string, secret string, user common.OCPUser) {
 	if !k8serrors.IsNotFound(err) {
 		Expect(err).Should(BeNil())
 	}
-
-	// Debug the kubeconfig file which in some cases gets corrupted with the grc e2e user
-	contents, err := os.ReadFile(common.KubeconfigHub)
-	if err != nil {
-		GinkgoWriter.Printf("DEBUG: hubkubeconfig read error: %s\n", common.KubeconfigHub)
-	} else {
-		length := len(contents)
-		if length > 1024 {
-			length = 1024
-		}
-		GinkgoWriter.Printf("DEBUG: hubkubeconfig contents: %s\n", string(contents)[:length])
-	}
 }
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated PolicySet in an App subscription", Label("policy-collection", "stable"), func() {


### PR DESCRIPTION
The debug logging has not helped to isolate the placement controller
issue with patching rules.

Signed-off-by: Gus Parvin <gparvin@redhat.com>