### PR TITLE
Increase the timeout in the generator test for placement propagation

### DIFF
--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -179,7 +179,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 				)
 				return err
 			},
-			defaultTimeoutSeconds,
+			defaultTimeoutSeconds*2,
 			1,
 		).Should(BeNil())
 


### PR DESCRIPTION
This test hasn't been stable in canaries, but works great when run
in local environments.  I think increasing the timeout may help

Refs:
 - https://github.com/stolostron/backlog/issues/22546

Signed-off-by: Gus Parvin <gparvin@redhat.com>