### PR TITLE
BVT failing in same testcase but different test times out

### DIFF
--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -125,7 +125,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 				)
 				return err
 			},
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(BeNil())
 


### PR DESCRIPTION
The same generator test is timing out waiting for the policyset to be
created.  Previously the timeout was waiting for the policyset to
propagate to the managed cluster, which is a later test.  Suspect
test environments are just causing this.

Refs:
 - https://github.com/stolostron/backlog/issues/22546

Signed-off-by: Gus Parvin <gparvin@redhat.com>