### PR TITLE
Backport the policy generator test fix to release-2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 deployOnHub ?= false
 RELEASE_BRANCH ?= main
 OCM_API_COMMIT ?= 3297cac74dc5e7fd2a82056cf3b93a5a88939d81
+DOCKER_URI ?= quay.io/stolostron
+VERSION_TAG ?= latest
 
 # GITHUB_USER containing '@' char must be escaped with '%40'
 GITHUB_USER := $(shell echo $(GITHUB_USER) | sed 's/@/%40/g')
@@ -147,22 +149,28 @@ kind-deploy-policy-framework:
 	else\
 		echo installing policy-spec-sync on managed;\
 		kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-spec-sync/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
+		kubectl patch deployment governance-policy-spec-sync -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+			-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-spec-sync\",\"image\":\"${DOCKER_URI}/governance-policy-spec-sync:${VERSION_TAG}\"}]}}}}";\
 	fi
+	@echo "installing policy-status-sync on managed"
+	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-status-sync/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	@if [ "$(deployOnHub)" = "true" ]; then\
-		echo installing policy-status-sync with ON_MULTICLUSTERHUB;\
-		kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-status-sync/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
+		echo patching policy-status-sync with ON_MULTICLUSTERHUB;\
 		kubectl set env deployment/governance-policy-status-sync ON_MULTICLUSTERHUB=true -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
-	else\
-		echo installing policy-status-sync on managed;\
-		kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-status-sync/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME);\
 	fi
+	kubectl patch deployment governance-policy-status-sync -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-status-sync\",\"image\":\"${DOCKER_URI}/governance-policy-status-sync:${VERSION_TAG}\"}]}}}}"
 	@echo installing policy-template-sync on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/governance-policy-template-sync/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl patch deployment governance-policy-template-sync -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-template-sync\",\"image\":\"${DOCKER_URI}/governance-policy-template-sync:${VERSION_TAG}\"}]}}}}"
 
 kind-deploy-config-policy-controller:
 	@echo installing config-policy-controller on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/config-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/config-policy-controller/$(RELEASE_BRANCH)/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl patch deployment config-policy-controller -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"config-policy-controller\",\"image\":\"${DOCKER_URI}/config-policy-controller:${VERSION_TAG}\"}]}}}}"
 
 kind-deploy-cert-policy-controller:
 	@echo installing cert-manager on managed
@@ -170,6 +178,8 @@ kind-deploy-cert-policy-controller:
 	@echo installing cert-policy-controller on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/$(RELEASE_BRANCH)/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl patch deployment cert-policy-controller -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"cert-policy-controller\",\"image\":\"${DOCKER_URI}/cert-policy-controller:${VERSION_TAG}\"}]}}}}"
 	kubectl patch deployment cert-policy-controller \
 		-n $(KIND_MANAGED_NAMESPACE) -p '{"spec": {"template": {"spec": {"containers": [{"name":"cert-policy-controller", "args": ["--enable-lease=true", "--hubconfig-secret-name=hub-kubeconfig"]}]}}}}' \
 		--kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
@@ -178,6 +188,8 @@ kind-deploy-iam-policy-controller:
 	@echo installing iam-policy-controller on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/iam-policy-controller/$(RELEASE_BRANCH)/deploy/crds/policy.open-cluster-management.io_iampolicies.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/iam-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl patch deployment iam-policy-controller -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
+		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"iam-policy-controller\",\"image\":\"${DOCKER_URI}/iam-policy-controller:${VERSION_TAG}\"}]}}}}"
 	kubectl patch deployment iam-policy-controller \
 		-n $(KIND_MANAGED_NAMESPACE) -p '{"spec": {"template": {"spec": {"containers": [{"name":"iam-policy-controller", "args": ["--enable-lease=true", "--hubconfig-secret-name=hub-kubeconfig"]}]}}}}' \
 		--kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ kind-delete-cluster:
 
 install-crds:
 	@echo installing crds on hub
-	kubectl apply -f https://raw.githubusercontent.com/stolostron/multicloud-operators-placementrule/$(RELEASE_BRANCH)/deploy/crds/apps.open-cluster-management.io_placementrules_crd.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
+	kubectl apply -f https://raw.githubusercontent.com/stolostron/multicloud-operators-subscription/$(RELEASE_BRANCH)/deploy/hub-common/apps.open-cluster-management.io_placementrules_crd.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/api/$(OCM_API_COMMIT)/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/api/$(OCM_API_COMMIT)/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/api/$(OCM_API_COMMIT)/cluster/v1beta1/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)

--- a/build/run-test-kind-prow.sh
+++ b/build/run-test-kind-prow.sh
@@ -33,7 +33,7 @@ scp "${OPT[@]}" /usr/local/bin/jq "${HOST}:/tmp/go/bin/"
 
 # Run the KinD script on the KinD instance
 echo "* Running E2E script on Kind cluster..."
-KIND_COMMAND="cd ${WORK_DIR} && GOROOT=/tmp/go PATH=\$GOROOT/bin:\$PATH deployOnHub=${deployOnHub} CGO_ENABLED=0 ./build/run-e2e-tests.sh"
+KIND_COMMAND="cd ${WORK_DIR} && GOROOT=/tmp/go PATH=\$GOROOT/bin:\$PATH deployOnHub=${deployOnHub} RELEASE_BRANCH=${PULL_BASE_REF} CGO_ENABLED=0 ./build/run-e2e-tests.sh"
 ssh "${OPT[@]}" "${HOST}" "${KIND_COMMAND}" > >(tee "${ARTIFACT_DIR}/test-e2e.log") 2>&1 || ERROR_CODE=$?
 
 # Copy any debug logs

--- a/build/run-test-kind-prow.sh
+++ b/build/run-test-kind-prow.sh
@@ -33,7 +33,11 @@ scp "${OPT[@]}" /usr/local/bin/jq "${HOST}:/tmp/go/bin/"
 
 # Run the KinD script on the KinD instance
 echo "* Running E2E script on Kind cluster..."
-KIND_COMMAND="cd ${WORK_DIR} && GOROOT=/tmp/go PATH=\$GOROOT/bin:\$PATH deployOnHub=${deployOnHub} RELEASE_BRANCH=${PULL_BASE_REF} CGO_ENABLED=0 ./build/run-e2e-tests.sh"
+VERSION_TAG="latest"
+if [ "${PULL_BASE_REF}" ] && [ "${PULL_BASE_REF}" != "main" ]; then
+  VERSION_TAG="${VERSION_TAG}-${PULL_BASE_REF#*-}"
+fi
+KIND_COMMAND="cd ${WORK_DIR} && GOROOT=/tmp/go PATH=\$GOROOT/bin:\$PATH deployOnHub=${deployOnHub} RELEASE_BRANCH=${PULL_BASE_REF} VERSION_TAG=${VERSION_TAG} CGO_ENABLED=0 ./build/run-e2e-tests.sh"
 ssh "${OPT[@]}" "${HOST}" "${KIND_COMMAND}" > >(tee "${ARTIFACT_DIR}/test-e2e.log") 2>&1 || ERROR_CODE=$?
 
 # Copy any debug logs

--- a/test/resources/policy_generator/subscription.yaml
+++ b/test/resources/policy_generator/subscription.yaml
@@ -40,6 +40,9 @@ spec:
     - apiVersion: policy.open-cluster-management.io/v1
       kinds:
         - "*"
+    - apiVersion: policy.open-cluster-management.io/v1beta1
+      kinds:
+        - "*"
     - apiVersion: apps.open-cluster-management.io/v1
       kinds:
         - PlacementRule


### PR DESCRIPTION
This fixes a testcase that is failing because the allow list does not
include PolicySets.  The policy set resource is version v1beta1 so
including that version in the allow list.

Refs:
 - https://github.com/stolostron/backlog/issues/22546

Signed-off-by: Gus Parvin <gparvin@redhat.com>