### PR TITLE
Hibernate E2E cluster when not in use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ before_script:
 jobs:
   include:
   - stage: prepare
+    name: Wake up cluster
+    if: type != pull_request AND type != push
+    script: ./build/set-claim.sh
+  - stage: prepare
     name: Patch cluster to latest
     if: type != pull_request AND type != push
     env:
@@ -75,6 +79,7 @@ jobs:
     after_failure:
     - export DEBUG_DIR="results/debug"
     - make e2e-debug-dump
+    - ./build/set-claim.sh --hibernate
   - stage: test-etcd-encryption
     name: Test etcd-encryption policy
     if: type != pull_request AND type != push
@@ -90,6 +95,7 @@ jobs:
     after_failure:
     - export DEBUG_DIR="results/debug"
     - make e2e-debug-dump
+    after_script: ./build/set-claim.sh --hibernate
   - stage: ff
     name: Fast forwarding GRC repos
     if: type != pull_request AND type != push

--- a/build/set-claim.sh
+++ b/build/set-claim.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+# Log into Collective cluster
+KUBECONFIG_FILE="${PWD}/kubeconfig-collective"
+touch ${KUBECONFIG_FILE}
+export KUBECONFIG=${KUBECONFIG_FILE}
+
+oc login --token=${COLLECTIVE_TOKEN} https://api.collective.aws.red-chesterfield.com:6443 &>/dev/null
+if [ $? = "0" ]; then
+  echo "Logged in to Collective cluster"
+else
+  echo "Failed to log in to Collective cluster"
+  exit 1
+fi
+
+# Set E2E ClusterClaim PowerState (Running/Hibernating)
+CLAIM="grce2e-policy-grc-cp-prow"
+
+if [ "$1" == "--hibernate" ]; then
+  POWER_STATE="Hibernating"
+else
+  POWER_STATE="Running"
+fi
+
+echo "Setting ClusterClaim ${CLAIM} to ${POWER_STATE}..."
+
+DEPLOYMENT=$(oc get clusterclaims.hive $CLAIM -o jsonpath={.spec.namespace})
+
+oc patch clusterdeployment.hive $DEPLOYMENT -n $DEPLOYMENT --type='merge' -p $'spec:\n powerState: '${POWER_STATE}''
+
+if [ "${POWER_STATE}" = "Running" ]; then
+  # Wait for ClusterClaim to be Running
+  for i in {1..10}; do
+    echo "Checking whether ClusterClaim ${CLAIM} is Running (${i}/10):"
+    oc wait --for=condition=ClusterRunning=True clusterclaims.hive/${CLAIM} --timeout 30s || EXIT_CODE=$?
+    if [ "${EXIT_CODE}" = "0" ]; then
+      break
+    fi
+  done
+fi
+
+rm ${KUBECONFIG_FILE}
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
This implements a hibernation flow that wakes up the `grce2e-policy-grc-cp-prow` ClusterClaim prior to the tests and hibernates it on completion.

Related to:
- https://github.com/stolostron/backlog/issues/14845