### PR TITLE
Install `oc` before `set-claim.sh` script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,11 @@ jobs:
   include:
   - stage: init
     name: Wake up cluster
-    script: ./build/set-claim.sh
+    script:
+    - |
+      make
+      make oc/install
+      ./build/set-claim.sh
   - stage: prepare
     name: Patch cluster to latest
     env:


### PR DESCRIPTION
It didn't occur to me that the labyrinth that is `build-harness-extensions` handled the install. This calls the `oc/install` target directly.