### PR TITLE
Use `sudo` to install CLIs

### DIFF
--- a/build/set-claim.sh
+++ b/build/set-claim.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Make sure we have `oc`
-./build/download-clis.sh
+sudo ./build/download-clis.sh
 
 # Log into Collective cluster
 KUBECONFIG_FILE="${PWD}/kubeconfig-collective"


### PR DESCRIPTION
This follows the pattern in `run-e2e-tests-policy-framework.sh`, so it should be the last change to get this thing off the ground (though I've been wrong before!) 😆 