### PR TITLE
Use Prow variable for dynamic image tag

### DIFF
--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -27,6 +27,13 @@ echo "* Install cert manager"
 $DIR/install-cert-manager.sh
 
 echo "* Set up cluster for test"
+# Set tag for images: Use `latest` for `main` and `latest-<version>` for `release-<version>` branches
+# `PULL_BASE_REF` is a variable provided by Prow: 
+# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
+export VERSION_TAG="latest"
+if [ "${PULL_BASE_REF}" ] && [ "${PULL_BASE_REF}" != "main" ]; then
+  export VERSION_TAG="${VERSION_TAG}-${PULL_BASE_REF#*-}"
+fi
 $DIR/patch-cluster-prow.sh
 cp ${HUB_KUBE} $DIR/../kubeconfig_hub
 cp ${MANAGED_KUBE} $DIR/../kubeconfig_managed

--- a/build/run-test-kind-prow.sh
+++ b/build/run-test-kind-prow.sh
@@ -33,6 +33,9 @@ scp "${OPT[@]}" /usr/local/bin/jq "${HOST}:/tmp/go/bin/"
 
 # Run the KinD script on the KinD instance
 echo "* Running E2E script on Kind cluster..."
+# Set tag for images: Use `latest` for `main` and `latest-<version>` for `release-<version>` branches
+# `PULL_BASE_REF` is a variable provided by Prow: 
+# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
 VERSION_TAG="latest"
 if [ "${PULL_BASE_REF}" ] && [ "${PULL_BASE_REF}" != "main" ]; then
   VERSION_TAG="${VERSION_TAG}-${PULL_BASE_REF#*-}"


### PR DESCRIPTION
This addresses the "cut a new release" script deficiency by allowing us to remove the environment variable from Prow and set it dynamically using a Prow variable, similar to this recently implemented code: https://github.com/stolostron/governance-policy-framework/blob/8006a5e88d3649647f3202caf6c1a739c2786d52/build/run-test-kind-prow.sh#L36-L39