### PR TITLE
Add qualified policy type name and pin gatekeeper operator version

### DIFF
--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -44,7 +44,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 			By("Creating policy on hub")
 			utils.KubectlWithOutput("apply", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Patching Policy Gatekeeper CR template with namespaceSelector to kubernetes.io/metadata.name=" + userNamespace)
-			utils.KubectlWithOutput("patch", "-n", userNamespace, "policy", gatekeeperPolicyName,
+			utils.KubectlWithOutput("patch", "-n", userNamespace, "policies.policy.open-cluster-management.io", gatekeeperPolicyName,
 				"--type=json", "-p=[{\"op\": \"add\", \"path\": \"/spec/policy-templates/2/objectDefinition/spec/object-templates/0/objectDefinition/spec/webhook/namespaceSelector\","+
 					" \"value\":{\"matchExpressions\":[{\"key\": \"grc\",\"operator\":\"In\",\"values\":[\"true\"]}]}}]",
 				"--kubeconfig="+kubeconfigHub)

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -60,7 +60,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 			utils.KubectlWithOutput("apply", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 
 			By("Patching Policy Gatekeeper CR template with namespaceSelector to kubernetes.io/metadata.name=" + userNamespace)
-			utils.KubectlWithOutput("patch", "-n", userNamespace, "policy", gatekeeperPolicyName,
+			utils.KubectlWithOutput("patch", "-n", userNamespace, "policies.policy.open-cluster-management.io", gatekeeperPolicyName,
 				"--type=json", "-p=[{\"op\": \"add\", \"path\": \"/spec/policy-templates/4/objectDefinition/spec/object-templates/0/objectDefinition/spec/webhook/namespaceSelector\","+
 					" \"value\":{\"matchExpressions\":[{\"key\": \"grc\",\"operator\":\"In\",\"values\":[\"true\"]}]}}]",
 				"--kubeconfig="+kubeconfigHub)

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -99,7 +99,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 						kyvernoDeployment,
 						kyvernoNamespace,
 						true,
-						defaultTimeoutSeconds,
+						defaultTimeoutSeconds*6,
 					).Object
 					if status, ok := pod["status"]; ok {
 						if ready, ok := status.(map[string]interface{})["readyReplicas"]; ok {

--- a/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
+++ b/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
@@ -41,7 +41,7 @@ spec:
                   displayName: Gatekeeper Operator Upstream
                   publisher: github.com/font/gatekeeper-operator
                   sourceType: grpc
-                  image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:latest'
+                  image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:v0.2.1'
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
Kyverno policies are also just called "policy", so the tests need to be
a little more specific when dealing with open-cluster-management.io
policies through kubectl commands.

In addition, the gatekeeper operator `latest` image was recently updated, and we need to pin to a specific version in order to keep it working.