### PR TITLE
Creation of deployment from subscription can take some time

### DIFF
--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -99,7 +99,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 						kyvernoDeployment,
 						kyvernoNamespace,
 						true,
-						defaultTimeoutSeconds,
+						defaultTimeoutSeconds*4,
 					).Object
 					if status, ok := pod["status"]; ok {
 						if ready, ok := status.(map[string]interface{})["readyReplicas"]; ok {


### PR DESCRIPTION
The deployment gets created when the subscription installs the kyverno
helm chart.  Sometimes this can take a while for the helm install to
start so the default timeout is really a bit short.  Increasing it to
reduce the concern here.

Signed-off-by: Gus Parvin <gparvin@redhat.com>