### PR TITLE
Gk audit timing

### DIFF
--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -202,6 +202,17 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 				return details[1].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Grabs the gatekeeper audit duration metric", func() {
+			auditPodName, _ := common.OcManaged("get", "pod", "-n=openshift-gatekeeper-system",
+				"-l=control-plane=audit-controller", `-o=jsonpath={.items[0].metadata.name}`)
+			common.OcManaged("exec", "-n=openshift-gatekeeper-system", auditPodName, "--", "bash",
+				"-c", "curl -s localhost:8888/metrics | grep -A1 audit_duration_seconds_sum")
+			/* example output:
+			gatekeeper-audit-9c88bf969-mgf5r
+			gatekeeper_audit_duration_seconds_sum 1005.4185594219999
+			gatekeeper_audit_duration_seconds_count 25
+			*/
+		})
 		It("Creating a valid ns should not be blocked by gatekeeper", func() {
 			By("Creating a namespace called e2etestsuccess on managed")
 			Eventually(func() interface{} {

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -193,7 +194,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		})
 		It("stable/policy-gatekeeper-sample should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
-			Eventually(getComplianceState(GKPolicyName), defaultTimeoutSeconds*12, 1).Should(Equal(policiesv1.Compliant))
+			Eventually(getComplianceState(GKPolicyName), 10*time.Minute, 1).Should(Equal(policiesv1.Compliant))
 			By("Checking if status for policy template policy-gatekeeper-audit is compliant")
 			Eventually(func() interface{} {
 				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -215,6 +215,17 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 				return details[1].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Grabs the gatekeeper audit duration metric", func() {
+			auditPodName, _ := common.OcManaged("get", "pod", "-n=openshift-gatekeeper-system",
+				"-l=control-plane=audit-controller", `-o=jsonpath={.items[0].metadata.name}`)
+			common.OcManaged("exec", "-n=openshift-gatekeeper-system", auditPodName, "--", "bash",
+				"-c", "curl -s localhost:8888/metrics | grep -A1 audit_duration_seconds_sum")
+			/* example output:
+			gatekeeper-audit-9c88bf969-mgf5r
+			gatekeeper_audit_duration_seconds_sum 1005.4185594219999
+			gatekeeper_audit_duration_seconds_count 25
+			*/
+		})
 		It("Creating a valid ns should not be blocked by gatekeeper", func() {
 			By("Creating a namespace called e2etestsuccess on managed")
 			Eventually(func() interface{} {

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -206,7 +207,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 		})
 		It("community/policy-gatekeeper-sample should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
-			Eventually(getComplianceState(GKPolicyName), defaultTimeoutSeconds*12, 1).Should(Equal(policiesv1.Compliant))
+			Eventually(getComplianceState(GKPolicyName), 10*time.Minute, 1).Should(Equal(policiesv1.Compliant))
 			By("Checking if status for policy template policy-gatekeeper-audit is compliant")
 			Eventually(func() interface{} {
 				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -86,7 +87,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
 				common.GetComplianceState(clientHubDynamic, userNamespace, "policy-install-kyverno", clusterNamespace),
-				defaultTimeoutSeconds*10,
+				10*time.Minute,
 				1,
 			).Should(Equal(policiesv1.Compliant))
 

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -168,7 +169,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 			fmt.Println("metric response received:")
 			fmt.Println(resp)
 			return resp
-		}, defaultTimeoutSeconds*8, 1).Should(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
+		}, 10*time.Minute, 1).Should(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
 	})
 	It("Checks that changing the policy to compliant removes the metric", func() {
 		By("Creating a compliant policy")
@@ -199,7 +200,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 			fmt.Println("metric response received:")
 			fmt.Println(resp)
 			return resp
-		}, defaultTimeoutSeconds*8, 1).ShouldNot(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
+		}, 10*time.Minute, 1).ShouldNot(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
 	})
 	AfterAll(func() {
 		// unset poll interval


### PR DESCRIPTION
The audit pod is taking a long time to complete and populate a field that the sample gatekeeper policy is checking for. This increases the timeout on that test, and should gather some information we can use to track how long the process is taking as the cluster ages.