### PR TITLE
Adjust PlacementRule patching logic

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -166,6 +166,8 @@ func OcManaged(args ...string) (string, error) {
 	return oc(args...)
 }
 
+// Patches the clusterSelector of the specified PlacementRule so that it will
+// always only match the targetCluster.
 func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) error {
 	_, err := utils.KubectlWithOutput(
 		"patch",
@@ -173,7 +175,8 @@ func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) er
 		namespace,
 		"placementrule.apps.open-cluster-management.io",
 		name,
-		"--type=json", "-p=[{\"op\": \"replace\", \"path\": \"/spec/clusterSelector/matchExpressions\", \"value\":[{\"key\": \"name\", \"operator\": \"In\", \"values\": ["+targetCluster+"]}]}]",
+		"--type=json",
+		`-p=[{"op": "replace", "path": "/spec/clusterSelector", "value":{"matchExpressions":[{"key": "name", "operator": "In", "values": ["`+targetCluster+`"]}]}}]`,
 		"--kubeconfig="+kubeconfigHub,
 	)
 

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -80,7 +80,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 
 			By("Patching the actual placement rule")
 			err = common.PatchPlacementRule(
-				kyvernoNamespace, "kyverno-placement-1", clusterNamespace, kubeconfigManaged,
+				kyvernoNamespace, "kyverno-placement-1", clusterNamespace, kubeconfigHub,
 			)
 			Expect(err).To(BeNil())
 

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -56,10 +56,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			Expect(len(templates)).Should(Equal(1))
 
 			By("Patching placement rule " + testPolicySetName + "-plr")
-			output, err = utils.KubectlWithOutput("patch", "-n", userNamespace, "placementrule.apps.open-cluster-management.io/"+testPolicySetName+"-plr",
-				"--type=json", "-p=[{\"op\": \"replace\", \"path\": \"/spec/clusterSelector/matchExpressions\", \"value\":[{\"key\": \"name\", \"operator\": \"In\", \"values\": ["+clusterNamespace+"]}]}]",
-				"--kubeconfig="+kubeconfigHub)
-			By("Patching placement rule result is " + output)
+			err = testcommon.PatchPlacementRule(
+				userNamespace, testPolicySetName+"-plr", clusterNamespace, kubeconfigHub,
+			)
 			Expect(err).To(BeNil())
 
 			By("Checking " + testPolicyName + " on managed cluster in ns " + clusterNamespace)


### PR DESCRIPTION
Previously, the common function ony replaced the `matchExpression` part
of the `clusterSelector`, in order to select the target cluster. If the
selector had a `matchLabels` section, then the resulting PlacementRule
might not select the target cluster, which was likely not the intent.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>