### PR TITLE
Manually add deprecated UI repos to CI check

### DIFF
--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -21,6 +21,8 @@ cloneRepos() {
 	if [ ! -d "${COMPONENT_ORG}" ]; then
 		# Collect repos from https://github.com/stolostron/policy-grc-squad/blob/master/main-branch-sync/repo.txt
 		REPOS=$(cat policy-grc-squad/main-branch-sync/repo.txt)
+		# Manually append deprecated repos
+		REPOS="${REPOS} stolostron/grc-ui stolostron/grc-ui-api"
 		for repo in $REPOS; do
 			echo "Cloning $repo ...."
 			git clone --quiet https://github.com/$repo.git $repo

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -4,7 +4,7 @@
 
 COMPONENT_ORG=stolostron
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-"main"}
-CHECK_RELEASES="2.3 2.4 2.5"
+CHECK_RELEASES="2.3 2.4 2.5 2.6"
 # This list can include all postsubmit jobs for all repos--if a job doesn't exist it's filtered to empty and skipped
 CHECK_JOBS=${CHECK_JOBS:-"publish publish-test images latest-image-mirror latest-test-image-mirror"}
 


### PR DESCRIPTION
There was a minor update to `grc-ui` that failed in CI but got missed since it was removed from the repo list. This manually adds deprecated repos to our script.