### PR TITLE
Add klusterlet addon pause annotation

### DIFF
--- a/build/patch-dev-images.sh
+++ b/build/patch-dev-images.sh
@@ -10,6 +10,7 @@ DOCKER_URI="quay.io/stolostron"
 
 echo "* Patching hub cluster to ${VERSION_TAG}"
 oc annotate MultiClusterHub multiclusterhub -n ${acm_installed_namespace} mch-pause=true --overwrite
+oc annotate klusterletaddonconfig -n ${acm_installed_namespace} ${acm_installed_namespace} klusterletaddonconfig-pause=true --overwrite=true
 
 # Patch the propagator on the hub
 COMPONENT="governance-policy-propagator"


### PR DESCRIPTION
The klusterlet-addon-controller was overriding our annotations on the
ManagedClusterAddOns, forcing them to use another image.

Co-authored-by: mprahl <mprahl@users.noreply.github.com>
Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>