### PR TITLE
Improve policy_governance_info metric RBAC tests

### DIFF
--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,8 +21,15 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		propagatorMetricsSelector = "component=ocm-policy-propagator"
 		ocmNS                     = "open-cluster-management"
 		metricName                = "policy_governance_info"
-		saName                    = "grc-framework-sa"
-		roleBindingName           = "grc-framework-role-binding"
+		metricsAccName            = "grc-framework-sa-metrics"
+		metricsTokenYaml          = "../resources/policy_info_metric/metrics_token.yaml"
+		metricsTokenName          = "grc-framework-sa-metrics-token-manual"
+		metricsRoleName           = "grc-framework-metrics-reader"
+		metricsRoleYaml           = "../resources/policy_info_metric/metrics_role.yaml"
+		noMetricsAccName          = "grc-framework-sa-nometrics"
+		noMetricsTokenYaml        = "../resources/policy_info_metric/nometrics_token.yaml"
+		noMetricsTokenName        = "grc-framework-sa-nometrics-token-manual"
+		roleBindingName           = "grc-framework-metrics-reader-binding"
 		compliantPolicyYaml       = "../resources/policy_info_metric/compliant.yaml"
 		compliantPolicyName       = "policy-metric-compliant"
 		noncompliantPolicyYaml    = "../resources/policy_info_metric/noncompliant.yaml"
@@ -31,7 +37,8 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 	)
 
 	var (
-		metricToken          string
+		metricsToken         string
+		noMetricsToken       string
 		propagatorMetricsURL string
 	)
 
@@ -71,37 +78,63 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		routeHost := routeList.Items[0].Object["spec"].(map[string]interface{})["host"].(string)
 		By("Got the metrics route url: " + routeHost)
 		propagatorMetricsURL = "https://" + routeHost + "/metrics"
-
-		// get auth token from service account
-		By("Setting up ServiceAccount for authentication")
-		_, err = common.OcHub("create", "serviceaccount", saName, "-n", userNamespace)
-		Expect(err).To(BeNil())
-		_, err = common.OcHub("create", "clusterrolebinding", roleBindingName, "--clusterrole=cluster-admin", fmt.Sprintf("--serviceaccount=%s:%s", userNamespace, saName))
+	})
+	It("Sets up a ServiceAccount without permissions for metrics", func() {
+		_, err := common.OcHub("create", "serviceaccount", noMetricsAccName, "-n", userNamespace)
 		Expect(err).To(BeNil())
 
-		// The secret can take a moment to be created, retry until it is in the cluster.
-		var tokenName string
-		Eventually(func() interface{} {
-			tokenNames, err := common.OcHub("get", fmt.Sprintf("serviceaccount/%s", saName), "-n", userNamespace, "-o", "jsonpath={.secrets[*].name}")
-			if err != nil {
-				return err
-			}
-			tokenNameArr := strings.Split(tokenNames, " ")
-			for _, name := range tokenNameArr {
-				if strings.HasPrefix(name, saName+"-token-") {
-					tokenName = name
-				}
-			}
-			return tokenName
-		}, defaultTimeoutSeconds, 1).Should(ContainSubstring(saName + "-token-"))
-
-		encodedtoken, err := common.OcHub("get", "secret", tokenName, "-n", userNamespace, "-o", "jsonpath={.data.token}")
+		_, err = common.OcHub("apply", "-f", noMetricsTokenYaml, "-n", userNamespace)
 		Expect(err).To(BeNil())
+
+		var encodedtoken string
+
+		// The secret could take a moment to be populated with the token
+		Eventually(func(g Gomega) {
+			var err error
+			encodedtoken, err = common.OcHub("get", "secret", noMetricsTokenName,
+				"-n", userNamespace, "-o", "jsonpath={.data.token}")
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(encodedtoken)).To(BeNumerically(">", 0))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
 		decodedToken, err := base64.StdEncoding.DecodeString(encodedtoken)
 		Expect(err).To(BeNil())
-		metricToken = string(decodedToken)
+
+		noMetricsToken = string(decodedToken)
 	})
-	It("Checks that the endpoint does not expose metrics without auth", func() {
+	It("Sets up a ServiceAccount with specific permission for metrics", func() {
+		_, err := common.OcHub("create", "serviceaccount", metricsAccName, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		_, err = common.OcHub("apply", "-f", metricsRoleYaml, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		_, err = common.OcHub("create", "clusterrolebinding", roleBindingName,
+			"--clusterrole="+metricsRoleName, "--serviceaccount="+userNamespace+":"+metricsAccName)
+		Expect(err).To(BeNil())
+
+		_, err = common.OcHub("apply", "-f", metricsTokenYaml, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		var encodedtoken string
+
+		// The secret could take a moment to be populated with the token
+		Eventually(func(g Gomega) {
+			var err error
+			encodedtoken, err = common.OcHub("get", "secret", metricsTokenName,
+				"-n", userNamespace, "-o", "jsonpath={.data.token}")
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(encodedtoken)).To(BeNumerically(">", 0))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		decodedToken, err := base64.StdEncoding.DecodeString(encodedtoken)
+		Expect(err).To(BeNil())
+
+		metricsToken = string(decodedToken)
+	})
+	It("Checks that the endpoint does not expose metrics to unauthenticated users", func() {
 		Eventually(func() interface{} {
 			_, status, err := common.GetWithToken(propagatorMetricsURL, "")
 			if err != nil {
@@ -110,13 +143,22 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 			return status
 		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("Unauthorized"))
 	})
+	It("Checks that the endpoint does not expose metrics to users without authorization", func() {
+		Eventually(func() interface{} {
+			_, status, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(noMetricsToken))
+			if err != nil {
+				return err
+			}
+			return status
+		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("403 Forbidden"))
+	})
 	It("Checks that endpoint has a HELP comment for the metric", func() {
 		By("Creating a policy")
 		common.OcHub("apply", "-f", compliantPolicyYaml, "-n", userNamespace)
 		// Don't need to check compliance - just need to guarantee there is a policy in the cluster
 
 		Eventually(func() interface{} {
-			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricToken))
+			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricsToken))
 			if err != nil {
 				return err
 			}
@@ -135,7 +177,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		By("Checking the policy metric")
 		policyLabel := `policy="` + compliantPolicyName + `"`
 		Eventually(func() interface{} {
-			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricToken))
+			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricsToken))
 			if err != nil {
 				return err
 			}
@@ -154,7 +196,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		By("Checking the policy metric")
 		policyLabel := `policy="` + noncompliantPolicyName + `"`
 		Eventually(func() interface{} {
-			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricToken))
+			resp, _, err := common.GetWithToken(propagatorMetricsURL, strings.TrimSpace(metricsToken))
 			if err != nil {
 				return err
 			}
@@ -165,8 +207,12 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		common.OcHub("delete", "-f", compliantPolicyYaml, "-n", userNamespace)
 		common.OcHub("delete", "-f", noncompliantPolicyYaml, "-n", userNamespace)
 		common.OcHub("delete", "route", "-n", ocmNS, "-l", propagatorMetricsSelector)
+		common.OcHub("delete", "clusterrole", metricsRoleName)
 		common.OcHub("delete", "clusterrolebinding", roleBindingName)
-		common.OcHub("delete", "serviceaccount", saName, "-n", userNamespace)
+		common.OcHub("delete", "serviceaccount", metricsAccName, "-n", userNamespace)
+		common.OcHub("delete", "serviceaccount", noMetricsAccName, "-n", userNamespace)
+		common.OcHub("delete", "secret", metricsTokenName, "-n", userNamespace)
+		common.OcHub("delete", "secret", noMetricsTokenName, "-n", userNamespace)
 		common.OcHub("delete", "namespace", "policy-metric-test-compliant")
 	})
 })

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -24,6 +24,8 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 		ocmNS                        = "open-cluster-management"
 		saName                       = "grc-framework-sa"
 		roleBindingName              = "grc-framework-role-binding"
+		saTokenName                  = "grc-framework-sa-token-manual"
+		saTokenYaml                  = "../resources/policy_report_metric/metrics_token.yaml"
 		insightsClientSelector       = "component=insights-client"
 		insightsMetricsSelector      = "component=insights-metrics"
 		insightsMetricName           = "policyreport_info"
@@ -117,34 +119,33 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 		routeHost := routeList.Items[0].Object["spec"].(map[string]interface{})["host"].(string)
 		By("Got the metrics route url: " + routeHost)
 		insightsMetricsURL = "https://" + routeHost + "/metrics"
-
-		// get auth token from service account
-		By("Setting up ServiceAccount for authentication")
-		_, err = common.OcHub("create", "serviceaccount", saName, "-n", userNamespace)
-		Expect(err).To(BeNil())
-		_, err = common.OcHub("create", "clusterrolebinding", roleBindingName, "--clusterrole=cluster-admin", fmt.Sprintf("--serviceaccount=%s:%s", userNamespace, saName))
+	})
+	It("Sets up a ServiceAccount with permissions for metrics", func() {
+		_, err := common.OcHub("create", "serviceaccount", saName, "-n", userNamespace)
 		Expect(err).To(BeNil())
 
-		// The secret can take a moment to be created, retry until it is in the cluster.
-		var tokenName string
-		Eventually(func() interface{} {
-			tokenNames, err := common.OcHub("get", fmt.Sprintf("serviceaccount/%s", saName), "-n", userNamespace, "-o", "jsonpath={.secrets[*].name}")
-			if err != nil {
-				return err
-			}
-			tokenNameArr := strings.Split(tokenNames, " ")
-			for _, name := range tokenNameArr {
-				if strings.HasPrefix(name, saName+"-token-") {
-					tokenName = name
-				}
-			}
-			return tokenName
-		}, defaultTimeoutSeconds, 1).Should(ContainSubstring(saName + "-token-"))
-
-		encodedtoken, err := common.OcHub("get", "secret", tokenName, "-n", userNamespace, "-o", "jsonpath={.data.token}")
+		_, err = common.OcHub("create", "clusterrolebinding", roleBindingName, "--clusterrole=cluster-admin",
+			fmt.Sprintf("--serviceaccount=%s:%s", userNamespace, saName))
 		Expect(err).To(BeNil())
+
+		_, err = common.OcHub("apply", "-f", saTokenYaml, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		var encodedtoken string
+
+		// The secret could take a moment to be populated with the token
+		Eventually(func(g Gomega) {
+			var err error
+			encodedtoken, err = common.OcHub("get", "secret", saTokenName,
+				"-n", userNamespace, "-o", "jsonpath={.data.token}")
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(encodedtoken)).To(BeNumerically(">", 0))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
 		decodedToken, err := base64.StdEncoding.DecodeString(encodedtoken)
 		Expect(err).To(BeNil())
+
 		insightsToken = string(decodedToken)
 	})
 	It("Checks that the endpoint does not expose metrics without auth", func() {

--- a/test/resources/policy_info_metric/metrics_role.yaml
+++ b/test/resources/policy_info_metric/metrics_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grc-framework-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/test/resources/policy_info_metric/metrics_token.yaml
+++ b/test/resources/policy_info_metric/metrics_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grc-framework-sa-metrics-token-manual
+  annotations:
+    kubernetes.io/service-account.name: grc-framework-sa-metrics
+type: kubernetes.io/service-account-token

--- a/test/resources/policy_info_metric/nometrics_token.yaml
+++ b/test/resources/policy_info_metric/nometrics_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grc-framework-sa-nometrics-token-manual
+  annotations:
+    kubernetes.io/service-account.name: grc-framework-sa-nometrics
+type: kubernetes.io/service-account-token

--- a/test/resources/policy_report_metric/metrics_token.yaml
+++ b/test/resources/policy_report_metric/metrics_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grc-framework-sa-token-manual
+  annotations:
+    kubernetes.io/service-account.name: grc-framework-sa
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
In newer versions of Kubernetes, tokens are not automatically created
for all service accounts. Therefore, the tests might need to manually
create the tokens for the service accounts it uses.

There is also a new test for users that should not have access to the
endpoint, whereas previously we only tested unauthenticated access.

Refs:
 - https://github.com/stolostron/backlog/issues/24075

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>