### PR TITLE
Kyverno cleanup is not properly removing the policy

### DIFF
--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -254,9 +254,14 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 			)
 		}
 
+		// remove the kyverno install policy
+		utils.KubectlWithOutput(
+			"delete", "-f", kyvernoInstallURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
+		)
+
 		// delete the subscription
 		utils.KubectlWithOutput(
-			"delete", "subscription.apps.open-cluster-management.io", "-n", kyvernoNamespace, "",
+			"delete", "subscription.apps.open-cluster-management.io", "-n", kyvernoNamespace, "--all",
 			"--kubeconfig="+kubeconfigManaged,
 		)
 


### PR DESCRIPTION
This impacts our e2e tests which have problems installing kyverno, but
this is really just a cleanup fix.  I don't think it solves the problem
with e2e failures, but it may help.

Signed-off-by: Gus Parvin <gparvin@redhat.com>