### PR TITLE
Move the policy-imagemanifestvuln test to SVT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,9 +180,6 @@ kind-deploy-cert-policy-controller:
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl patch deployment cert-policy-controller -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
 		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"cert-policy-controller\",\"image\":\"${DOCKER_URI}/cert-policy-controller:${VERSION_TAG}\"}]}}}}"
-	kubectl patch deployment cert-policy-controller \
-		-n $(KIND_MANAGED_NAMESPACE) -p '{"spec": {"template": {"spec": {"containers": [{"name":"cert-policy-controller", "args": ["--enable-lease=true", "--hubconfig-secret-name=hub-kubeconfig"]}]}}}}' \
-		--kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 
 kind-deploy-iam-policy-controller:
 	@echo installing iam-policy-controller on managed
@@ -190,9 +187,6 @@ kind-deploy-iam-policy-controller:
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/iam-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl patch deployment iam-policy-controller -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) \
 		-p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"iam-policy-controller\",\"image\":\"${DOCKER_URI}/iam-policy-controller:${VERSION_TAG}\"}]}}}}"
-	kubectl patch deployment iam-policy-controller \
-		-n $(KIND_MANAGED_NAMESPACE) -p '{"spec": {"template": {"spec": {"containers": [{"name":"iam-policy-controller", "args": ["--enable-lease=true", "--hubconfig-secret-name=hub-kubeconfig"]}]}}}}' \
-		--kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 
 kind-deploy-olm:
 	@echo installing OLM on managed

--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -41,7 +41,7 @@ fi
 echo "===== E2E Test ====="
 echo "* Launching grc policy framework test"
 # Run test suite with reporting
-CGO_ENABLED=0 ginkgo -v --no-color --fail-fast ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+CGO_ENABLED=0 $DIR/../bin/ginkgo -v --no-color --fail-fast ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
 
 # Remove Ginkgo phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -141,7 +141,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyUrl string, scanName st
 	})
 }
 
-var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance operator and scan", Label("policy-collection", "stable", "BVT"), func() {
+var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance operator and scan", Label("policy-collection", "stable"), func() {
 	const compPolicyURL = policyCollectCAURL + "policy-compliance-operator-install.yaml"
 	const compPolicyName = "policy-comp-operator"
 	const compE8ScanPolicyURL = policyCollectCMURL + "policy-compliance-operator-e8-scan.yaml"

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -44,7 +44,7 @@ var _ = Describe("RHACM4K-3055", Label("policy-collection", "stable", "BVT"), fu
 			By("Creating policy on hub")
 			utils.KubectlWithOutput("apply", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Patching Policy Gatekeeper CR template with namespaceSelector to kubernetes.io/metadata.name=" + userNamespace)
-			utils.KubectlWithOutput("patch", "-n", userNamespace, "policy", gatekeeperPolicyName,
+			utils.KubectlWithOutput("patch", "-n", userNamespace, "policies.policy.open-cluster-management.io", gatekeeperPolicyName,
 				"--type=json", "-p=[{\"op\": \"add\", \"path\": \"/spec/policy-templates/2/objectDefinition/spec/object-templates/0/objectDefinition/spec/webhook/namespaceSelector\","+
 					" \"value\":{\"matchExpressions\":[{\"key\": \"grc\",\"operator\":\"In\",\"values\":[\"true\"]}]}}]",
 				"--kubeconfig="+kubeconfigHub)

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -60,7 +60,7 @@ var _ = Describe("", Label("policy-collection", "community"), func() {
 			utils.KubectlWithOutput("apply", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 
 			By("Patching Policy Gatekeeper CR template with namespaceSelector to kubernetes.io/metadata.name=" + userNamespace)
-			utils.KubectlWithOutput("patch", "-n", userNamespace, "policy", gatekeeperPolicyName,
+			utils.KubectlWithOutput("patch", "-n", userNamespace, "policies.policy.open-cluster-management.io", gatekeeperPolicyName,
 				"--type=json", "-p=[{\"op\": \"add\", \"path\": \"/spec/policy-templates/4/objectDefinition/spec/object-templates/0/objectDefinition/spec/webhook/namespaceSelector\","+
 					" \"value\":{\"matchExpressions\":[{\"key\": \"grc\",\"operator\":\"In\",\"values\":[\"true\"]}]}}]",
 				"--kubeconfig="+kubeconfigHub)

--- a/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
+++ b/test/resources/gatekeeper/policy-gatekeeper-operator.yaml
@@ -41,7 +41,7 @@ spec:
                   displayName: Gatekeeper Operator Upstream
                   publisher: github.com/font/gatekeeper-operator
                   sourceType: grpc
-                  image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:latest'
+                  image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:v0.2.1'
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
This test is flaky and the errors are almost never indicative of an
actual issue with the GRC code. This should be an SVT test instead for
those reasons.

This also cherry-picks some changes to make the CI pass.

This is backporting #401.