### PR TITLE
Use the hub kubeconfig to patch the placement

### DIFF
--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -79,7 +79,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator policie
 
 		By("Patching the actual placement rule")
 		err = common.PatchPlacementRule(
-			kyvernoNamespace, "kyverno-placement-1", clusterNamespace, kubeconfigManaged,
+			kyvernoNamespace, "kyverno-placement-1", clusterNamespace, kubeconfigHub,
 		)
 		Expect(err).To(BeNil())
 


### PR DESCRIPTION
Failure in SVT test due to the kubeconfig being used was managed cluster
kubeconfig instead of hub.

Refs:
 - https://github.com/stolostron/backlog/issues/24410

Signed-off-by: Gus Parvin <gparvin@redhat.com>