### PR TITLE
Add tests for pruneObjectBehavior feature

### DIFF
--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -7,6 +7,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 var (
 	GvrPod                   = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 	GvrNS                    = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	GvrConfigMap             = schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
 	GvrRole                  = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
 	GvrCRD                   = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 	GvrPolicy                = schema.GroupVersionResource{Group: "policy.open-cluster-management.io", Version: "v1", Resource: "policies"}

--- a/test/configuration_policy_prune.go
+++ b/test/configuration_policy_prune.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/stolostron/governance-policy-framework/test/common"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	pruneConfigMapName string = "test-prune-configmap"
+	pruneConfigMapYaml string = "../resources/configuration_policy_prune/configmap-only.yaml"
+)
+
+func ConfigPruneBehavior(labels ...string) bool {
+	pruneTestCreatedByPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
+		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
+		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
+
+		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+
+		By("Checking that the configmap was created")
+		utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", true, DefaultTimeoutSeconds)
+
+		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		By("Checking if the configmap was deleted")
+		utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", !cmShouldBeDeleted, DefaultTimeoutSeconds)
+	}
+
+	pruneTestInformPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
+		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
+		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
+
+		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+
+		By("Checking that the configmap was created")
+		utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", true, DefaultTimeoutSeconds)
+
+		By("Changing the policy to inform")
+		OcHub("patch", "policies.policy.open-cluster-management.io", policyName, "-n", UserNamespace,
+			"--type=json", "-p", `[{"op":"replace", "path":"/spec/remediationAction", "value":"inform"}]`)
+
+		By("Wait for configpolicy to update to inform")
+		Eventually(func() interface{} {
+			configpol := utils.GetWithTimeout(clientManagedDynamic, GvrConfigurationPolicy, policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+			if configpol == nil {
+				return errors.New("could not get configuration policy")
+			}
+
+			remAction, _, _ := unstructured.NestedString(configpol.Object, "spec", "remediationAction")
+			return remAction
+		}, DefaultTimeoutSeconds, 1).Should(MatchRegexp(".nform"))
+
+		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		By("Checking if the configmap was deleted")
+		utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", !cmShouldBeDeleted, DefaultTimeoutSeconds)
+	}
+
+	pruneTestEditedByPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
+		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
+		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
+
+		By("Creating the configmap before the policy")
+		OcManaged("apply", "-f", pruneConfigMapYaml)
+
+		By("Checking the configmap's initial data")
+		var initialValue string
+		Eventually(func(g Gomega) {
+			cm := utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", true, DefaultTimeoutSeconds)
+			data, ok, err := unstructured.NestedMap(cm.Object, "data")
+			g.Expect(ok).To(BeTrue())
+			g.Expect(err).To(BeNil())
+
+			initialValue, ok = data["testvalue"].(string)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(len(initialValue)).To(BeNumerically(">", 0))
+		}, DefaultTimeoutSeconds, 1)
+
+		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+
+		By("Checking the configmap's data was updated")
+		Eventually(func(g Gomega) {
+			cm := utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", true, DefaultTimeoutSeconds)
+			data, ok, err := unstructured.NestedMap(cm.Object, "data")
+			g.Expect(ok).To(BeTrue())
+			g.Expect(err).To(BeNil())
+
+			newValue, ok := data["testvalue"].(string)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(newValue).To(Not(Equal(initialValue)))
+		}, DefaultTimeoutSeconds, 1)
+
+		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, &GvrConfigurationPolicy)
+
+		By("Checking if the configmap was deleted")
+		utils.GetWithTimeout(clientManagedDynamic, GvrConfigMap, pruneConfigMapName, "default", !cmShouldBeDeleted, DefaultTimeoutSeconds)
+	}
+
+	Describe("GRC: [P1][Sev1][policy-grc] Test configuration policy pruning", Ordered, Label(labels...), func() {
+		cleanConfigMap := func() {
+			OcManaged("delete", "-f", pruneConfigMapYaml)
+		}
+		BeforeEach(cleanConfigMap)
+		AfterAll(cleanConfigMap)
+
+		cleanPolicy := func(policyName, policyYaml string) func() {
+			return func() {
+				OcHub("delete", "-f", policyYaml)
+				OcManaged("delete", "events", "-n", ClusterNamespace, "--field-selector=involvedObject.name="+UserNamespace+"."+policyName)
+			}
+		}
+
+		Describe("Test DeleteAll pruning", func() {
+			policyName := "cm-policy-prune-all"
+			policyYaml := "../resources/configuration_policy_prune/cm-policy-prune-all.yaml"
+
+			BeforeEach(cleanPolicy(policyName, policyYaml))
+			AfterAll(cleanPolicy(policyName, policyYaml))
+
+			It("Should delete the configmap created by a DeleteAll policy when the policy is deleted", func() {
+				pruneTestCreatedByPolicy(policyName, policyYaml, true)
+			})
+			It("Should not delete the configmap when the policy is in inform mode", func() {
+				pruneTestInformPolicy(policyName, policyYaml, false)
+			})
+			It("Should delete the configmap edited by a DeleteAll policy when the policy is deleted", func() {
+				pruneTestEditedByPolicy(policyName, policyYaml, true)
+			})
+		})
+
+		Describe("Test DeleteIfCreated pruning", func() {
+			policyName := "cm-policy-prune-if-created"
+			policyYaml := "../resources/configuration_policy_prune/cm-policy-prune-if-created.yaml"
+
+			BeforeEach(cleanPolicy(policyName, policyYaml))
+			AfterAll(cleanPolicy(policyName, policyYaml))
+
+			It("Should delete the configmap created by a DeleteIfCreated policy when the policy is deleted", func() {
+				pruneTestCreatedByPolicy(policyName, policyYaml, true)
+			})
+			It("Should not delete the configmap edited by a DeleteIfCreated policy when the policy is deleted", func() {
+				pruneTestEditedByPolicy(policyName, policyYaml, false)
+			})
+		})
+
+		Describe("Test None pruning", func() {
+			policyName := "cm-policy-prune-none"
+			policyYaml := "../resources/configuration_policy_prune/cm-policy-prune-none.yaml"
+
+			BeforeEach(cleanPolicy(policyName, policyYaml))
+			AfterAll(cleanPolicy(policyName, policyYaml))
+
+			It("Should not delete the configmap created by a None policy when the policy is deleted", func() {
+				pruneTestCreatedByPolicy(policyName, policyYaml, false)
+			})
+			It("Should not delete the configmap edited by a None policy when the policy is deleted", func() {
+				pruneTestEditedByPolicy(policyName, policyYaml, false)
+			})
+		})
+
+		Describe("Test default pruning", func() {
+			policyName := "cm-policy-prune-default"
+			policyYaml := "../resources/configuration_policy_prune/cm-policy-prune-default.yaml"
+
+			BeforeEach(cleanPolicy(policyName, policyYaml))
+			AfterAll(cleanPolicy(policyName, policyYaml))
+
+			It("Should not delete the configmap created by a policy that doesn't specify a Prune behavior when the policy is deleted", func() {
+				pruneTestCreatedByPolicy(policyName, policyYaml, false)
+			})
+			It("Should not delete the configmap edited by a policy that doesn't specify a Prune behavior when the policy is deleted", func() {
+				pruneTestEditedByPolicy(policyName, policyYaml, false)
+			})
+		})
+	})
+
+	return true
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
+	"github.com/stolostron/governance-policy-framework/test"
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
@@ -40,6 +41,8 @@ func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
 }
+
+var _ = test.ConfigPruneBehavior()
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")

--- a/test/resources/configuration_policy_prune/cm-policy-prune-all.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-all.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: cm-policy-prune-all
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: cm-policy-prune-all
+        spec:
+          pruneObjectBehavior: DeleteAll
+          remediationAction: enforce
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: test-prune-configmap
+                data:
+                  testvalue: bulbasaur
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: cm-policy-prune-all-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: cm-policy-prune-all-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: cm-policy-prune-all
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: cm-policy-prune-all-plr
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-default.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-default.yaml
@@ -1,0 +1,54 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: cm-policy-prune-default
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: cm-policy-prune-default
+        spec:
+          remediationAction: enforce
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: test-prune-configmap
+                data:
+                  testvalue: squirtle
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: cm-policy-prune-default-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: cm-policy-prune-default-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: cm-policy-prune-default
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: cm-policy-prune-default-plr
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-if-created.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-if-created.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: cm-policy-prune-if-created
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: cm-policy-prune-if-created
+        spec:
+          pruneObjectBehavior: DeleteIfCreated
+          remediationAction: enforce
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: test-prune-configmap
+                data:
+                  testvalue: charmander
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: cm-policy-prune-if-created-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: cm-policy-prune-if-created-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: cm-policy-prune-if-created
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: cm-policy-prune-if-created-plr
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-none.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-none.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: cm-policy-prune-none
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: cm-policy-prune-none
+        spec:
+          pruneObjectBehavior: None
+          remediationAction: enforce
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: test-prune-configmap
+                data:
+                  testvalue: celebi
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: cm-policy-prune-none-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: cm-policy-prune-none-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: cm-policy-prune-none
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: cm-policy-prune-none-plr
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/configuration_policy_prune/configmap-only.yaml
+++ b/test/resources/configuration_policy_prune/configmap-only.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-prune-configmap
+data:
+  testvalue: mew


### PR DESCRIPTION
Tests the general functionality of this new feature.

These tests are in a new (experimental) format that allow them to
be run in our usual KinD tests (under e2e) as well as in our larger set
of tests that run against real clusters (under integration). This
format would also potentially allow us to turn tests on and off
separately from the ginkgo filters, which could be helpful because the
filters cause tests to be *skipped*, which impacts test execution stats.

Refs:
 - https://github.com/stolostron/backlog/issues/24440

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>