### PR TITLE
Use Ordered Describes and After/BeforeAll nodes (#331)

### DIFF
--- a/test/e2e/hub_templates_encryption_test.go
+++ b/test/e2e/hub_templates_encryption_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-var _ = Describe("Test Hub Template Encryption", func() {
+var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 	Describe("Test that a secret can be securely copied to managed clusters", func() {
 		ctx := context.TODO()
 		const policyName = "test-hub-encryption"
@@ -260,7 +260,7 @@ var _ = Describe("Test Hub Template Encryption", func() {
 			).Should(Equal(expectedTriggerUpdate))
 		})
 
-		It("Cleans up", func() {
+		AfterAll(func() {
 			err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Delete(
 				ctx, policyName, metav1.DeleteOptions{},
 			)

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -25,8 +25,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-certificate policy", Label("policy-collection", "stable", "BVT"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-certificate policy", Ordered, Label("policy-collection", "stable", "BVT"), func() {
 	const (
 		policyCertificateName   = "policy-certificate"
 		policyCertificateURL    = policyCollectSCURL + policyCertificateName + ".yaml"
@@ -133,7 +132,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-certificate policy
 		).Should(Equal(policiesv1.NonCompliant))
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyCertificateURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Label("policy-collection", "stable", "etcd"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption policy", Ordered, Label("policy-collection", "stable", "etcd"), func() {
 	const (
 		policyEtcdEncryptionName = "policy-etcdencryption"
 		policyEtcdEncryptionURL  = policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
@@ -127,7 +126,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-etcdencryption pol
 		).Should(Equal("aescbc"))
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyEtcdEncryptionURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("RHACM4K-3055", Label("policy-collection", "stable", "BVT"), func() {
+var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "BVT"), func() {
 	var getComplianceState func(policyName string) func() interface{}
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		if isOCP44() {
 			Skip("Skipping as this is ocp 4.4")
 		}
@@ -397,54 +397,51 @@ var _ = Describe("RHACM4K-3055", Label("policy-collection", "stable", "BVT"), fu
 		})
 	})
 
-	Describe("GRC: [P1][Sev1][policy-grc] Clean up after all", func() {
-		It("Clean up mutation policies", func() {
-			utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignMetadataPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
-				return managedPlc
-			}, defaultTimeoutSeconds, 1).Should(BeNil())
-			utils.KubectlWithOutput("delete", "-f", GKAssignPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
-				return managedPlc
-			}, defaultTimeoutSeconds, 1).Should(BeNil())
-			utils.KubectlWithOutput("delete", "-f", "../resources/gatekeeper/pod-mutation.yaml", "-n", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
-		})
-		It("Clean up stable/policy-gatekeeper-sample", func() {
-			utils.KubectlWithOutput("delete", "-f", GKPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
-				return managedPlc
-			}, defaultTimeoutSeconds, 1).Should(BeNil())
-			utils.KubectlWithOutput("delete", "ns", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "ns", "e2etestfail", "--kubeconfig="+kubeconfigManaged)
-		})
-		It("Clean up stable/policy-gatekeeper-operator", func() {
-			utils.KubectlWithOutput("delete", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
-				return managedPlc
-			}, defaultTimeoutSeconds, 1).Should(BeNil())
-			utils.Pause(20)
-			utils.KubectlWithOutput("delete", "Gatekeeper", "gatekeeper", "--kubeconfig="+kubeconfigManaged)
-			Eventually(func() interface{} {
-				out, _ := utils.KubectlWithOutput("get", "pods", "-n", "openshift-gatekeeper-system", "--kubeconfig="+kubeconfigManaged)
-				return out
-			}, defaultTimeoutSeconds*4, 1).Should(ContainSubstring("No resources found")) // k8s will respond with this even if the ns was deleted.
-			utils.KubectlWithOutput("delete", "-n", "openshift-operators", "subscriptions.operators.coreos.com", "gatekeeper-operator-product", "--kubeconfig="+kubeconfigManaged)
-			csvName, _ := utils.KubectlWithOutput("get", "-n", "openshift-operators", "csv", "-o", "jsonpath=\"{.items[?(@.spec.displayName==\"Gatekeeper Operator\")].metadata.name}\"", "--kubeconfig="+kubeconfigManaged)
-			csvName = strings.Trim(csvName, "\"")
-			utils.KubectlWithOutput("delete", "-n", "openshift-operators", "csv", csvName, "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "crd", "gatekeepers.operator.gatekeeper.sh", "--kubeconfig="+kubeconfigManaged)
-			out, _ := utils.KubectlWithOutput("delete", "ns", "openshift-gatekeeper-system", "--kubeconfig="+kubeconfigManaged)
-			Expect(out).To(Or(
-				ContainSubstring("namespace \"openshift-gatekeeper-system\" deleted"),
-				ContainSubstring("namespaces \"openshift-gatekeeper-system\" not found")))
-			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper", "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-image-pull-policy", "--kubeconfig="+kubeconfigManaged)
-			utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-annotation-owner", "--kubeconfig="+kubeconfigManaged)
-		})
+	AfterAll(func() {
+		// Clean up mutation policies
+		utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignMetadataPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+			return managedPlc
+		}, defaultTimeoutSeconds, 1).Should(BeNil())
+		utils.KubectlWithOutput("delete", "-f", GKAssignPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKAssignPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+			return managedPlc
+		}, defaultTimeoutSeconds, 1).Should(BeNil())
+		utils.KubectlWithOutput("delete", "-f", "../resources/gatekeeper/pod-mutation.yaml", "-n", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
+		// Clean up stable/policy-gatekeeper-sample
+		utils.KubectlWithOutput("delete", "-f", GKPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+			return managedPlc
+		}, defaultTimeoutSeconds, 1).Should(BeNil())
+		utils.KubectlWithOutput("delete", "ns", "e2etestsuccess", "--kubeconfig="+kubeconfigManaged)
+		utils.KubectlWithOutput("delete", "ns", "e2etestfail", "--kubeconfig="+kubeconfigManaged)
+		// Clean up stable/policy-gatekeeper-operator
+		utils.KubectlWithOutput("delete", "-f", gatekeeperPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, common.GvrPolicy, userNamespace+"."+gatekeeperPolicyName, clusterNamespace, false, defaultTimeoutSeconds)
+			return managedPlc
+		}, defaultTimeoutSeconds, 1).Should(BeNil())
+		utils.Pause(20)
+		utils.KubectlWithOutput("delete", "Gatekeeper", "gatekeeper", "--kubeconfig="+kubeconfigManaged)
+		Eventually(func() interface{} {
+			out, _ := utils.KubectlWithOutput("get", "pods", "-n", "openshift-gatekeeper-system", "--kubeconfig="+kubeconfigManaged)
+			return out
+		}, defaultTimeoutSeconds*4, 1).Should(ContainSubstring("No resources found")) // k8s will respond with this even if the ns was deleted.
+		utils.KubectlWithOutput("delete", "-n", "openshift-operators", "subscriptions.operators.coreos.com", "gatekeeper-operator-product", "--kubeconfig="+kubeconfigManaged)
+		csvName, _ := utils.KubectlWithOutput("get", "-n", "openshift-operators", "csv", "-o", "jsonpath=\"{.items[?(@.spec.displayName==\"Gatekeeper Operator\")].metadata.name}\"", "--kubeconfig="+kubeconfigManaged)
+		csvName = strings.Trim(csvName, "\"")
+		utils.KubectlWithOutput("delete", "-n", "openshift-operators", "csv", csvName, "--kubeconfig="+kubeconfigManaged)
+		utils.KubectlWithOutput("delete", "crd", "gatekeepers.operator.gatekeeper.sh", "--kubeconfig="+kubeconfigManaged)
+		out, _ := utils.KubectlWithOutput("delete", "ns", "openshift-gatekeeper-system", "--kubeconfig="+kubeconfigManaged)
+		Expect(out).To(Or(
+			ContainSubstring("namespace \"openshift-gatekeeper-system\" deleted"),
+			ContainSubstring("namespaces \"openshift-gatekeeper-system\" not found")))
+		utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-operator", "--kubeconfig="+kubeconfigManaged)
+		utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper", "--kubeconfig="+kubeconfigManaged)
+		utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-image-pull-policy", "--kubeconfig="+kubeconfigManaged)
+		utils.KubectlWithOutput("delete", "events", "-n", clusterNamespace, "--field-selector=involvedObject.name="+userNamespace+".policy-gatekeeper-annotation-owner", "--kubeconfig="+kubeconfigManaged)
 	})
 })

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -49,7 +49,7 @@ func cleanup(namespace string, secret string, user common.OCPUser) {
 	}
 }
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated PolicySet in an App subscription", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated PolicySet in an App subscription", Ordered, Label("policy-collection", "stable"), func() {
 	const namespace = "policies"
 	const secret = "grc-e2e-subscription-admin-user"
 	const clustersetRoleName = "grc-e2e-clusterset-role"
@@ -254,7 +254,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated P
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		By("Cleaning up the changes made to the cluster in the test")
 		cleanup(namespace, secret, ocpUser)
 	})

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an App subscription", Label("BVT"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an App subscription", Ordered, Label("BVT"), func() {
 	const namespace = "grc-e2e-policy-generator"
 	const secret = "grc-e2e-subscription-admin-user"
 	const subAdminBinding = "open-cluster-management:subscription-admin"
@@ -198,7 +198,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		By("Cleaning up the changes made to the cluster in the test")
 		cleanup(namespace, secret, ocpUser)
 	})

--- a/test/integration/policy_hub_templates_21440_test.go
+++ b/test/integration/policy_hub_templates_21440_test.go
@@ -20,6 +20,7 @@ import (
 // See https://github.com/stolostron/backlog/issues/21440
 var _ = Describe(
 	"GRC: [P1][Sev2][policy-grc] Test that the text/template backport is included (21440)",
+	Ordered,
 	Label("policy-collection", "stable"),
 	func() {
 		const (
@@ -106,7 +107,7 @@ var _ = Describe(
 			).Should(Equal("redhat.com"))
 		})
 
-		It("Cleans up", func() {
+		AfterAll(func() {
 			_, err := utils.KubectlWithOutput(
 				"delete", "-f", policyYAML, "-n", "default", "--kubeconfig="+kubeconfigHub,
 			)

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 // Note that these tests must be run on OpenShift since the tests create an OpenShift group
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin policy", Label("policy-collection", "stable", "BVT"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin policy", Ordered, Label("policy-collection", "stable", "BVT"), func() {
 	const (
 		iamPolicyName             = "policy-limitclusteradmin"
 		iamPolicyURL              = policyCollectACURL + iamPolicyName + ".yaml"
@@ -95,7 +94,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin 
 		Eventually(getIAMComplianceState, defaultTimeoutSeconds*10, 1).Should(Equal(policiesv1.Compliant))
 	})
 
-	It("Clean up stable/"+iamPolicyName, func() {
+	AfterAll(func() {
 		err := clientManaged.CoreV1().Namespaces().Delete(context.TODO(), iamPolicyManagedNamespace, metav1.DeleteOptions{})
 		Expect(err).Should(BeNil())
 		utils.KubectlWithOutput("delete", "-f", iamPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln policy", Ordered, Label("policy-collection", "stable", "BVT"), func() {
 	const policyIMVURL = policyCollectSIURL + "policy-imagemanifestvuln.yaml"
 	const policyIMVName = "policy-imagemanifestvuln"
 	const subName = "container-security-operator"
@@ -187,7 +187,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 		).Should(Equal(policiesv1.NonCompliant))
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyIMVURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", Label("BVT"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", Ordered, Label("BVT"), func() {
 	const (
 		propagatorMetricsSelector = "component=ocm-policy-propagator"
 		ocmNS                     = "open-cluster-management"
@@ -204,7 +203,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 			return resp
 		}, defaultTimeoutSeconds, 1).Should(common.MatchMetricValue(metricName, policyLabel, "1"))
 	})
-	It("Cleans up", func() {
+	AfterAll(func() {
 		common.OcHub("delete", "-f", compliantPolicyYaml, "-n", userNamespace)
 		common.OcHub("delete", "-f", noncompliantPolicyYaml, "-n", userNamespace)
 		common.OcHub("delete", "route", "-n", ocmNS, "-l", propagatorMetricsSelector)

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy", Label("policy-collection", "stable"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyLimitMemoryName   = "policy-limitmemory"
 		policyLimitMemoryURL    = policyCollectSCURL + policyLimitMemoryName + ".yaml"
@@ -119,7 +118,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyLimitMemoryURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy", Label("policy-collection", "stable"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyNamespaceName = "policy-namespace"
 		policyNamespaceURL  = policyCollectCMURL + policyNamespaceName + ".yaml"
@@ -99,7 +98,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyNamespaceURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyPodName   = "policy-pod"
 		policyPodURL    = policyCollectCMURL + policyPodName + ".yaml"
@@ -119,7 +119,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy", Label
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyPodURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		rootPolicyName   = "policy-podsecuritypolicy"
 		rootPolicyURL    = policyCollectSCURL + "policy-psp.yaml"
@@ -125,7 +125,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy", Label
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		By("Deleting the PodSecurityPolicy " + rootPolicyName + " on the hub cluster")
 		_, err := utils.KubectlWithOutput(
 			"delete",

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Label("BVT"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Ordered, Label("BVT"), func() {
 	const (
 		ocmNS                        = "open-cluster-management"
 		saName                       = "grc-framework-sa"
@@ -203,7 +202,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", La
 			return resp
 		}, defaultTimeoutSeconds*8, 1).ShouldNot(common.MatchMetricValue(insightsMetricName, policyLabel, "1"))
 	})
-	It("Cleans up", func() {
+	AfterAll(func() {
 		// unset poll interval
 		insightsClient, err := common.OcHub("get", "deployments", "-n", ocmNS, "-l", insightsClientSelector, "-o", "name")
 		Expect(err).To(BeNil())

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyRoleName   = "policy-role"
 		policyRoleURL    = policyCollectACURL + policyRoleName + ".yaml"
@@ -117,7 +117,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy", Labe
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyRoleURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy", Label("policy-collection", "stable"), func() {
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyRoleBindingName   = "policy-rolebinding"
 		policyRoleBindingURL    = policyCollectACURL + policyRoleBindingName + ".yaml"
@@ -117,7 +117,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", policyRoleBindingURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Label("policy-collection", "stable"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		rootPolicyName   = "policy-securitycontextconstraints"
 		rootPolicyURL    = policyCollectSCURL + "policy-scc.yaml"
@@ -109,7 +108,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy", Label
 		).Should(BeNil())
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		_, err := utils.KubectlWithOutput(
 			"delete", "-f", rootPolicyURL, "-n", userNamespace, "--kubeconfig="+kubeconfigHub,
 		)

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -15,8 +15,7 @@ import (
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )
 
-var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Label("BVT"), func() {
-
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("BVT"), func() {
 	const (
 		testPolicyName             string = "test-policy"
 		testPolicySetName          string = "test-policyset"
@@ -199,7 +198,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Label("BVT"), fu
 			).Should(utils.SemanticEqual(yamlPlc.Object["status"]))
 		})
 
-		It("should clean up", func() {
+		AfterAll(func() {
 			output, err := utils.KubectlWithOutput("delete",
 				"-f", testPolicySetYaml,
 				"-n", userNamespace,


### PR DESCRIPTION
Backport of PR https://github.com/stolostron/governance-policy-framework/pull/331 to release-2.5 for issue:
- https://github.com/stolostron/backlog/issues/23871

Since fail-fast was turned on for the tests, some of the "clean up" test
nodes are not being run. A better fit for those is "AfterAll" nodes,
which require the Describes to be marked as Ordered.

In addition, some BeforeEach test nodes would fit better as BeforeAll,
since that is now possible.

Note: adding "Ordered" to the Describes largely does not change the
behavior. Unless the `--randomize-all` flag is passed, the It nodes
will be run in the order they are defined anyway.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>