### PR TITLE
Fix assertions wrapped in Eventuallys

### DIFF
--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -144,10 +144,10 @@ var _ = Describe("Test gatekeeper", Ordered, func() {
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
 				return details[1].(map[string]interface{})["history"]
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
-				Expect(details[1].(map[string]interface{})["history"]).NotTo(BeNil())
+				g.Expect(details[1].(map[string]interface{})["history"]).NotTo(BeNil())
 				return details[1].(map[string]interface{})["history"].([]interface{})[0].(map[string]interface{})["message"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant; notification - k8srequiredlabels [ns-must-have-gk] found as specified, therefore this Object template is compliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-admission is compliant")

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -99,9 +99,9 @@ func complianceScanTest(scanPolicyName string, scanPolicyUrl string, scanName st
 	})
 	It("ComplianceCheckResult should be created", func() {
 		By("Checking if any ComplianceCheckResult CR exists on managed cluster")
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			list, err := clientManagedDynamic.Resource(common.GvrComplianceCheckResult).Namespace("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			return len(list.Items)
 		}, common.MaxTravisTimeoutSeconds, 1).ShouldNot(Equal(0))
 	})
@@ -134,9 +134,9 @@ func complianceScanTest(scanPolicyName string, scanPolicyUrl string, scanName st
 		By("Wait for compliancescan to be deleted")
 		utils.ListWithTimeoutByNamespace(clientManagedDynamic, common.GvrComplianceScan, metav1.ListOptions{}, "openshift-compliance", 0, false, defaultTimeoutSeconds)
 		By("Wait for other pods to be deleted in openshift-compliance ns")
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			return len(podList.Items)
 		}, defaultTimeoutSeconds*4, 1).Should(Equal(3))
 	})
@@ -201,7 +201,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 		It("Compliance operator pod should be running", func() {
 			By("Checking if pod compliance-operator has been created")
 			var i int = 0
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				if i == 60*2 || i == 60*4 {
 					fmt.Println("compliance operator pod still not created, deleting subscription and let it recreate", i)
 					utils.KubectlWithOutput("get", "-n", "openshift-compliance", "subscriptions.operators.coreos.com", "compliance-operator", "-oyaml", "--kubeconfig="+kubeconfigManaged)
@@ -209,39 +209,39 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 				}
 				i++
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "name=compliance-operator"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*12, 1).Should(Equal(1))
 			By("Checking if pod compliance-operator is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "name=compliance-operator"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
 			}, defaultTimeoutSeconds*6, 1).Should(Equal("Running"))
 		})
 		It("Profile bundle pods should be running", func() {
 			By("Checking if pod ocp4-pp has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=ocp4"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*6, 1).Should(Equal(1))
 			By("Checking if pod ocp4-pp is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=ocp4"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
 			}, defaultTimeoutSeconds*8, 1).Should(Equal("Running"))
 			By("Checking if pod rhcos4-pp has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=rhcos4"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*6, 1).Should(Equal(1))
 			By("Checking if pod rhcos4-pp is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{LabelSelector: "profile-bundle=rhcos4"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
 			}, defaultTimeoutSeconds*8, 1).Should(Equal("Running"))
 		})

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -83,20 +83,20 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		It("Gatekeeper operator pod should be running", func() {
 			By("Checking if pod gatekeeper-operator has been created")
 			var i int = 0
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				if i == 60*2 || i == 60*4 {
 					fmt.Println("gatekeeper operator pod still not created, deleting subscription and let it recreate", i)
 					utils.KubectlWithOutput("delete", "-n", "openshift-operators", "subscriptions.operators.coreos.com", "gatekeeper-operator-product", "--kubeconfig="+kubeconfigManaged)
 				}
 				i++
 				podList, err := clientManaged.CoreV1().Pods("openshift-operators").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*12, 1).Should(Equal(1))
 			By("Checking if pod gatekeeper-operator is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-operators").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				for _, item := range podList.Items {
 					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
 						return string(item.Status.Phase)
@@ -125,29 +125,29 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		})
 		It("Gatekeeper audit pod should be running", func() {
 			By("Checking if pod gatekeeper-audit has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*2, 1).Should(Equal(1))
 			By("Checking if pod gatekeeper-audit is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
 			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 		It("Gatekeeper controller manager pods should be running", func() {
 			By("Checking if pod gatekeeper-controller-manager has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*2, 1).Should(Equal(2))
 			By("Checking if pod gatekeeper-controller-manager is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase) + "/" + string(podList.Items[1].Status.Phase)
 			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running/Running"))
 		})

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -100,15 +100,15 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 		})
 		It("Gatekeeper operator pod should be running", func() {
 			By("Checking if pod gatekeeper-operator-controller-manager has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*8, 1).ShouldNot(Equal(0))
 			By("Checking if pod gatekeeper-operator-controller-manager is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-operator").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane in (controller-manager, gatekeeper-operator-controller-manager)"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				for _, item := range podList.Items {
 					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
 						return string(item.Status.Phase)
@@ -137,30 +137,30 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 		})
 		It("Gatekeeper audit pod should be running", func() {
 			By("Checking if pod gatekeeper-audit has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*2, 1).Should(Equal(1))
 			By("Checking if pod gatekeeper-audit is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=audit-controller"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase)
 			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running"))
 		})
 
 		It("Gatekeeper controller manager pods should be running", func() {
 			By("Checking if pod gatekeeper-controller-manager has been created")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return len(podList.Items)
 			}, defaultTimeoutSeconds*2, 1).Should(Equal(2))
 			By("Checking if pod gatekeeper-controller-manager is running")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				podList, err := clientManaged.CoreV1().Pods("openshift-gatekeeper-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "control-plane=controller-manager"})
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return string(podList.Items[0].Status.Phase) + "/" + string(podList.Items[1].Status.Phase)
 			}, defaultTimeoutSeconds*4, 1).Should(Equal("Running/Running"))
 		})

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -79,11 +79,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-1.yaml")
 
 			policySetRsrc := clientHubDynamic.Resource(testcommon.GvrPolicySet)
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				rootPlcSet, err := policySetRsrc.Namespace(userNamespace).Get(
 					context.TODO(), testPolicySetName, metav1.GetOptions{},
 				)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return rootPlcSet.Object["status"]
 			},
 				defaultTimeoutSeconds*2,
@@ -104,11 +104,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-2.yaml")
 
 			policySetRsrc := clientHubDynamic.Resource(testcommon.GvrPolicySet)
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				rootPlcSet, err := policySetRsrc.Namespace(userNamespace).Get(
 					context.TODO(), testPolicySetName, metav1.GetOptions{},
 				)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return rootPlcSet.Object["status"]
 			},
 				defaultTimeoutSeconds*2,
@@ -147,11 +147,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-3.yaml")
 
 			policySetRsrc := clientHubDynamic.Resource(testcommon.GvrPolicySet)
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				rootPlcSet, err := policySetRsrc.Namespace(userNamespace).Get(
 					context.TODO(), testPolicySetName, metav1.GetOptions{},
 				)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return rootPlcSet.Object["status"]
 			},
 				defaultTimeoutSeconds*2,
@@ -185,11 +185,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-4.yaml")
 
 			policySetRsrc := clientHubDynamic.Resource(testcommon.GvrPolicySet)
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				rootPlcSet, err := policySetRsrc.Namespace(userNamespace).Get(
 					context.TODO(), testPolicySetName, metav1.GetOptions{},
 				)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				return rootPlcSet.Object["status"]
 			},
 				defaultTimeoutSeconds*2,


### PR DESCRIPTION
When an assertion is made in an `Eventually`, it must use the input
`Gomega` argument to avoid a failed assertion from failing the
`Eventually` before it times out.

One example is a flaky network connection failure an SVT test:
https://github.com/stolostron/backlog/issues/24895