### PR TITLE
Minor update to log gatekeeper operator install problem

### DIFF
--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -99,6 +99,10 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
 					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
+						// Log the pod status message if there may be a problem starting the pod
+						if len(item.Status.Conditions) > 0 && item.Status.Conditions[0].Status == "False" {
+							GinkgoWriter.Println("Pod status error message: " + item.Status.Conditions[0].Message)
+						}
 						return string(item.Status.Phase)
 					}
 				}

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -111,6 +111,10 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 				Expect(err).To(BeNil())
 				for _, item := range podList.Items {
 					if strings.HasPrefix(item.ObjectMeta.Name, "gatekeeper-operator-controller") {
+						// Log the pod status message if there may be a problem starting the pod
+						if len(item.Status.Conditions) > 0 && item.Status.Conditions[0].Status == "False" {
+							GinkgoWriter.Println("Pod status error message: " + item.Status.Conditions[0].Message)
+						}
 						return string(item.Status.Phase)
 					}
 				}


### PR DESCRIPTION
If the operator doesn't install, this should log why.  Typical failures
have been image pull issues from OLM, but resource issues could be
detected too.

Refs:
 - https://github.com/stolostron/backlog/issues/23871

Signed-off-by: Gus Parvin <gparvin@redhat.com>