### PR TITLE
Pin the oc client version to 4.10.21

### DIFF
--- a/build/download-clis.sh
+++ b/build/download-clis.sh
@@ -9,7 +9,7 @@ set -e
 if ! which oc > /dev/null; then
     echo "Installing oc and kubectl clis..."
     mkdir clis-unpacked
-    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.21/openshift-client-linux.tar.gz
     tar -xzf oc.tar.gz -C clis-unpacked
     chmod 755 ./clis-unpacked/oc
     chmod 755 ./clis-unpacked/kubectl

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -14,7 +14,7 @@ fi
 if ! which oc > /dev/null; then
     echo "Installing oc and kubectl clis..."
     mkdir clis-unpacked
-    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.21/openshift-client-linux.tar.gz
     tar -xzf oc.tar.gz -C clis-unpacked
     chmod +x ./clis-unpacked/oc
     chmod +x ./clis-unpacked/kubectl


### PR DESCRIPTION
Some recent failures have been caused by the openshift client version;
when a test exposes a service as a route, it provides an `--overrides`
paramter that was being ignored in newer client versions.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>