### PR TITLE
Change command used to expose service

### DIFF
--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -62,7 +62,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 
 		if len(routeList.Items) == 0 {
 			By("Exposing the metrics service as a route")
-			_, err = common.OcHub("expose", "service", metricsSvc.Name, "-n", ocmNS, `--overrides={"spec":{"tls":{"termination":"reencrypt"}}}`)
+			_, err = common.OcHub("create", "route", "reencrypt", metricsSvc.Name, "--service="+metricsSvc.Name, "-n", ocmNS)
 			Expect(err).To(BeNil())
 
 			Eventually(func() interface{} {

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -133,7 +133,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 
 		if len(routeList.Items) == 0 {
 			By("Exposing the insights metrics service as a route")
-			_, err = common.OcHub("expose", "service", metricsSvc.Name, "-n", ocmNS, `--overrides={"spec":{"tls":{"termination":"reencrypt"}}}`)
+			_, err = common.OcHub("create", "route", "reencrypt", metricsSvc.Name, "--service="+metricsSvc.Name, "-n", ocmNS)
 			Expect(err).To(BeNil())
 
 			Eventually(func() interface{} {


### PR DESCRIPTION
Different versions of the openshift client handle `--overrides` in the
`oc expose service` command differently. This updates the tests to use
a command that should work more consistently.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>