### PR TITLE
Pin the oc client version to 4.10.21

### DIFF
--- a/build/download-clis.sh
+++ b/build/download-clis.sh
@@ -9,7 +9,7 @@ set -e
 if ! which oc > /dev/null; then
     echo "Installing oc and kubectl clis..."
     mkdir clis-unpacked
-    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.21/openshift-client-linux.tar.gz
     tar -xzf oc.tar.gz -C clis-unpacked
     chmod 755 ./clis-unpacked/oc
     chmod 755 ./clis-unpacked/kubectl

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -11,12 +11,15 @@ else
     echo "with managed cluster..."
 fi
 
-if ! which kubectl > /dev/null; then
-    KUBECTL_VERSION=${KUBECTL_VERSION:-"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"}
-    echo "* Installing kubectl ${KUBECTL_VERSION}..."
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/
+if ! which oc > /dev/null; then
+    echo "Installing oc and kubectl clis..."
+    mkdir clis-unpacked
+    curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.21/openshift-client-linux.tar.gz
+    tar -xzf oc.tar.gz -C clis-unpacked
+    chmod +x ./clis-unpacked/oc
+    chmod +x ./clis-unpacked/kubectl
+    sudo mv ./clis-unpacked/kubectl /usr/local/bin/
+    sudo mv ./clis-unpacked/oc /usr/local/bin/
 fi
 if ! which kind > /dev/null; then
     KIND_VERSION=${KIND_VERSION:-"$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '.tag_name')"}


### PR DESCRIPTION
Some recent failures have been caused by the openshift client version;
when a test exposes a service as a route, it provides an `--overrides`
paramter that was being ignored in newer client versions.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit a7565ed5550bda51a12a6376a925cd0ba801533c)