### PR TITLE
Pin the OLM version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
 endif
 
 # Fetch OLM version
-OLM_VERSION ?= $(shell curl -s https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest | jq -r '.tag_name')
+OLM_VERSION ?= v0.21.2
 
 # Debugging configuration
 KIND_COMPONENTS := config-policy-controller cert-policy-controller iam-policy-controller governance-policy-spec-sync governance-policy-status-sync governance-policy-template-sync
@@ -235,9 +235,7 @@ kind-deploy-iam-policy-controller:
 kind-deploy-olm:
 	@echo installing OLM on managed
 	export KUBECONFIG=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
-	curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$(OLM_VERSION)/install.sh -o install.sh
-	# Workaround for https://github.com/operator-framework/operator-lifecycle-manager/issues/2767
-	sed -i 's_kubectl apply -f "$${url}/crds.yaml"_kubectl create -f "$${url}/crds.yaml"_' install.sh
+	curl --fail -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$(OLM_VERSION)/install.sh -o install.sh
 	chmod +x install.sh
 	./install.sh $(OLM_VERSION)
 


### PR DESCRIPTION
Recently, OLM 0.22.0 was released which didn't contain the install.sh
script in the GitHub release assets and caused the policy framework
tests to fail. This pins the version to prevent that.