### PR TITLE
Common function refactoring

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -3,7 +3,6 @@
 package common
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -14,18 +13,12 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 
-	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
@@ -135,29 +128,6 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 	return nil, fmt.Errorf("could not create a valid kubeconfig")
 }
 
-// GetComplianceState returns a function that requires no arguments that retrieves the
-// compliance state of the input policy.
-func GetComplianceState(
-	clientHubDynamic dynamic.Interface,
-	namespace, policyName,
-	clusterNamespace string,
-) func(Gomega) interface{} {
-	return func(g Gomega) interface{} {
-		rootPlc := utils.GetWithTimeout(clientHubDynamic, GvrPolicy, policyName, namespace, true, DefaultTimeoutSeconds)
-		var policy policiesv1.Policy
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(rootPlc.UnstructuredContent(), &policy)
-		g.ExpectWithOffset(1, err).To(BeNil())
-
-		for _, statusPerCluster := range policy.Status.Status {
-			if statusPerCluster.ClusterNamespace == clusterNamespace {
-				return statusPerCluster.ComplianceState
-			}
-		}
-
-		return nil
-	}
-}
-
 func oc(args ...string) (string, error) {
 	// Determine whether output should be logged
 	printOutput := true
@@ -209,121 +179,6 @@ func OcManaged(args ...string) (string, error) {
 	return oc(args...)
 }
 
-// Patches the clusterSelector of the specified PlacementRule so that it will
-// always only match the targetCluster.
-func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) error {
-	_, err := utils.KubectlWithOutput(
-		"patch",
-		"-n",
-		namespace,
-		"placementrule.apps.open-cluster-management.io",
-		name,
-		"--type=json",
-		`-p=[{"op": "replace", "path": "/spec/clusterSelector", `+
-			`"value":{"matchExpressions":[{"key": "name", "operator": "In", "values": ["`+
-			targetCluster+`"]}]}}]`,
-		"--kubeconfig="+kubeconfigHub,
-	)
-
-	return err
-}
-
-// DoCreatePolicyTest runs usual assertions around creating a policy. It will
-// create the given policy file to the hub cluster, on the user namespace. It
-// also patches the PlacementRule with a PlacementDecision if required. It
-// asserts that the policy was distributed to the managed cluster, and for any
-// templateGVRs supplied, it asserts that a policy template of that type (for
-// example ConfigurationPolicy) and the same name was created on the managed
-// cluster.
-//
-// It assumes that the given filename (stripped of an extension) matches the
-// name of the policy, and that the PlacementRule has the same name, with '-plr'
-// appended.
-func DoCreatePolicyTest(
-	hub,
-	managed dynamic.Interface,
-	policyFile string,
-	templateGVRs ...schema.GroupVersionResource,
-) {
-	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
-
-	By("DoCreatePolicyTest creates " + policyFile + "on namespace" + UserNamespace)
-	output, err := OcHub("apply", "-f", policyFile, "-n", UserNamespace)
-	ExpectWithOffset(1, err).To(BeNil())
-	By("DoCreatePolicyTest OcHub apply output " + output)
-
-	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, true, DefaultTimeoutSeconds)
-	ExpectWithOffset(1, plc).NotTo(BeNil())
-
-	if ManuallyPatchDecisions {
-		plrName := policyName + "-plr"
-		By("Patching " + plrName + " with decision of cluster " + ClusterNamespace)
-		plr := utils.GetWithTimeout(hub, GvrPlacementRule, plrName, UserNamespace, true, DefaultTimeoutSeconds)
-		plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespace)
-		_, err := hub.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
-			context.TODO(),
-			plr,
-			metav1.UpdateOptions{},
-		)
-		ExpectWithOffset(1, err).To(BeNil())
-	}
-
-	managedPolicyName := UserNamespace + "." + policyName
-	By("Checking " + managedPolicyName + " on managed cluster in ns " + ClusterNamespace)
-	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, true, DefaultTimeoutSeconds)
-	ExpectWithOffset(1, mplc).NotTo(BeNil())
-
-	for _, tmplGVR := range templateGVRs {
-		typedName := tmplGVR.String() + "/" + policyName
-		By("Checking that the policy template " + typedName + " is present on the managed cluster")
-
-		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
-		ExpectWithOffset(1, tmplPlc).NotTo(BeNil())
-	}
-}
-
-// DoCleanupPolicy deletes the resources specified in the file, and asserts that
-// the propagated policy was removed from the managed cluster. For each templateGVR,
-// it will check that there is no longer a policy template (for example
-// ConfigurationPolicy) of the same name on the managed cluster.
-func DoCleanupPolicy(hub, managed dynamic.Interface, policyFile string, templateGVRs ...schema.GroupVersionResource) {
-	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
-	By("Deleting " + policyFile)
-	_, err := OcHub(
-		"delete", "-f", policyFile, "-n", UserNamespace,
-		"--ignore-not-found",
-	)
-	Expect(err).To(BeNil())
-
-	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, false, DefaultTimeoutSeconds)
-	ExpectWithOffset(1, plc).To(BeNil())
-
-	managedPolicyName := UserNamespace + "." + policyName
-	By("Checking " + managedPolicyName + " was removed from managed cluster in ns " + ClusterNamespace)
-	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, false, DefaultTimeoutSeconds)
-	ExpectWithOffset(1, mplc).To(BeNil())
-
-	for _, tmplGVR := range templateGVRs {
-		typedName := tmplGVR.String() + "/" + policyName
-		By("Checking that the policy template " + typedName + " was removed from the managed cluster")
-
-		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, false, DefaultTimeoutSeconds)
-		ExpectWithOffset(1, tmplPlc).To(BeNil())
-	}
-}
-
-// DoRootComplianceTest asserts that the given policy has the given compliance
-// on the root policy on the hub cluster.
-func DoRootComplianceTest(hub dynamic.Interface, policyName string, compliance policiesv1.ComplianceState) {
-	By("Checking if the status of root policy " + policyName + " is " + string(compliance))
-	EventuallyWithOffset(
-		1,
-		GetComplianceState(hub, UserNamespace, policyName, ClusterNamespace),
-		DefaultTimeoutSeconds,
-		1,
-	).Should(Equal(compliance))
-}
-
 func OutputDebugInfo(testName string, kubeconfig string, additionalResources ...string) {
 	GinkgoWriter.Printf("%s test Kubernetes info:\n", testName)
 
@@ -338,40 +193,4 @@ func OutputDebugInfo(testName string, kubeconfig string, additionalResources ...
 	for _, resource := range resources {
 		_, _ = utils.KubectlWithOutput("get", resource, "--all-namespaces", "-o", "yaml", "--kubeconfig="+kubeconfig)
 	}
-}
-
-// GetLatestStatusMessage returns the most recent status message for the given policy template.
-// If the policy, template, or status do not exist for any reason, an empty string is returned.
-func GetLatestStatusMessage(managed dynamic.Interface, policyName string, templateIdx int) string {
-	replicatedPolicyName := UserNamespace + "." + policyName
-	policyInterface := managed.Resource(GvrPolicy).Namespace(ClusterNamespace)
-
-	policy, err := policyInterface.Get(context.TODO(), replicatedPolicyName, metav1.GetOptions{})
-	if err != nil {
-		return ""
-	}
-
-	details, found, err := unstructured.NestedSlice(policy.Object, "status", "details")
-	if !found || err != nil || len(details) <= templateIdx {
-		return ""
-	}
-
-	templateDetails, ok := details[templateIdx].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	history, found, err := unstructured.NestedSlice(templateDetails, "history")
-	if !found || err != nil || len(history) == 0 {
-		return ""
-	}
-
-	topHistoryItem, ok := history[0].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	message, _, _ := unstructured.NestedString(topHistoryItem, "message")
-
-	return message
 }

--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -1,0 +1,194 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package common
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+// GetComplianceState returns a function that requires no arguments that retrieves the
+// compliance state of the input policy.
+func GetComplianceState(
+	clientHubDynamic dynamic.Interface,
+	namespace, policyName,
+	clusterNamespace string,
+) func(Gomega) interface{} {
+	return func(g Gomega) interface{} {
+		rootPlc := utils.GetWithTimeout(clientHubDynamic, GvrPolicy, policyName, namespace, true, DefaultTimeoutSeconds)
+		var policy policiesv1.Policy
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(rootPlc.UnstructuredContent(), &policy)
+		g.ExpectWithOffset(1, err).To(BeNil())
+
+		for _, statusPerCluster := range policy.Status.Status {
+			if statusPerCluster.ClusterNamespace == clusterNamespace {
+				return statusPerCluster.ComplianceState
+			}
+		}
+
+		return nil
+	}
+}
+
+// Patches the clusterSelector of the specified PlacementRule so that it will
+// always only match the targetCluster.
+func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) error {
+	_, err := utils.KubectlWithOutput(
+		"patch",
+		"-n",
+		namespace,
+		"placementrule.apps.open-cluster-management.io",
+		name,
+		"--type=json",
+		`-p=[{"op": "replace", "path": "/spec/clusterSelector", `+
+			`"value":{"matchExpressions":[{"key": "name", "operator": "In", "values": ["`+
+			targetCluster+`"]}]}}]`,
+		"--kubeconfig="+kubeconfigHub,
+	)
+
+	return err
+}
+
+// DoCreatePolicyTest runs usual assertions around creating a policy. It will
+// create the given policy file to the hub cluster, on the user namespace. It
+// also patches the PlacementRule with a PlacementDecision if required. It
+// asserts that the policy was distributed to the managed cluster, and for any
+// templateGVRs supplied, it asserts that a policy template of that type (for
+// example ConfigurationPolicy) and the same name was created on the managed
+// cluster.
+//
+// It assumes that the given filename (stripped of an extension) matches the
+// name of the policy, and that the PlacementRule has the same name, with '-plr'
+// appended.
+func DoCreatePolicyTest(
+	hub,
+	managed dynamic.Interface,
+	policyFile string,
+	templateGVRs ...schema.GroupVersionResource,
+) {
+	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
+
+	By("DoCreatePolicyTest creates " + policyFile + "on namespace" + UserNamespace)
+	output, err := OcHub("apply", "-f", policyFile, "-n", UserNamespace)
+	ExpectWithOffset(1, err).To(BeNil())
+	By("DoCreatePolicyTest OcHub apply output " + output)
+
+	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, true, DefaultTimeoutSeconds)
+	ExpectWithOffset(1, plc).NotTo(BeNil())
+
+	if ManuallyPatchDecisions {
+		plrName := policyName + "-plr"
+		By("Patching " + plrName + " with decision of cluster " + ClusterNamespace)
+		plr := utils.GetWithTimeout(hub, GvrPlacementRule, plrName, UserNamespace, true, DefaultTimeoutSeconds)
+		plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespace)
+		_, err := hub.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
+			context.TODO(),
+			plr,
+			metav1.UpdateOptions{},
+		)
+		ExpectWithOffset(1, err).To(BeNil())
+	}
+
+	managedPolicyName := UserNamespace + "." + policyName
+	By("Checking " + managedPolicyName + " on managed cluster in ns " + ClusterNamespace)
+	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+	ExpectWithOffset(1, mplc).NotTo(BeNil())
+
+	for _, tmplGVR := range templateGVRs {
+		typedName := tmplGVR.String() + "/" + policyName
+		By("Checking that the policy template " + typedName + " is present on the managed cluster")
+
+		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+		ExpectWithOffset(1, tmplPlc).NotTo(BeNil())
+	}
+}
+
+// DoCleanupPolicy deletes the resources specified in the file, and asserts that
+// the propagated policy was removed from the managed cluster. For each templateGVR,
+// it will check that there is no longer a policy template (for example
+// ConfigurationPolicy) of the same name on the managed cluster.
+func DoCleanupPolicy(hub, managed dynamic.Interface, policyFile string, templateGVRs ...schema.GroupVersionResource) {
+	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
+	By("Deleting " + policyFile)
+	_, err := OcHub(
+		"delete", "-f", policyFile, "-n", UserNamespace,
+		"--ignore-not-found",
+	)
+	Expect(err).To(BeNil())
+
+	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, false, DefaultTimeoutSeconds)
+	ExpectWithOffset(1, plc).To(BeNil())
+
+	managedPolicyName := UserNamespace + "." + policyName
+	By("Checking " + managedPolicyName + " was removed from managed cluster in ns " + ClusterNamespace)
+	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, false, DefaultTimeoutSeconds)
+	ExpectWithOffset(1, mplc).To(BeNil())
+
+	for _, tmplGVR := range templateGVRs {
+		typedName := tmplGVR.String() + "/" + policyName
+		By("Checking that the policy template " + typedName + " was removed from the managed cluster")
+
+		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, false, DefaultTimeoutSeconds)
+		ExpectWithOffset(1, tmplPlc).To(BeNil())
+	}
+}
+
+// DoRootComplianceTest asserts that the given policy has the given compliance
+// on the root policy on the hub cluster.
+func DoRootComplianceTest(hub dynamic.Interface, policyName string, compliance policiesv1.ComplianceState) {
+	By("Checking if the status of root policy " + policyName + " is " + string(compliance))
+	EventuallyWithOffset(
+		1,
+		GetComplianceState(hub, UserNamespace, policyName, ClusterNamespace),
+		DefaultTimeoutSeconds,
+		1,
+	).Should(Equal(compliance))
+}
+
+// GetLatestStatusMessage returns the most recent status message for the given policy template.
+// If the policy, template, or status do not exist for any reason, an empty string is returned.
+func GetLatestStatusMessage(managed dynamic.Interface, policyName string, templateIdx int) string {
+	replicatedPolicyName := UserNamespace + "." + policyName
+	policyInterface := managed.Resource(GvrPolicy).Namespace(ClusterNamespace)
+
+	policy, err := policyInterface.Get(context.TODO(), replicatedPolicyName, metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+
+	details, found, err := unstructured.NestedSlice(policy.Object, "status", "details")
+	if !found || err != nil || len(details) <= templateIdx {
+		return ""
+	}
+
+	templateDetails, ok := details[templateIdx].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	history, found, err := unstructured.NestedSlice(templateDetails, "history")
+	if !found || err != nil || len(history) == 0 {
+		return ""
+	}
+
+	topHistoryItem, ok := history[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	message, _, _ := unstructured.NestedString(topHistoryItem, "message")
+
+	return message
+}

--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -14,20 +14,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
 // GetComplianceState returns a function usable by ginkgo.Eventually that retrieves the
 // compliance state of the input policy.
-func GetComplianceState(
-	clientHubDynamic dynamic.Interface,
-	namespace, policyName,
-	clusterNamespace string,
-) func(Gomega) interface{} {
+func GetComplianceState(namespace, policyName, clusterNamespace string) func(Gomega) interface{} {
 	return func(g Gomega) interface{} {
-		rootPlc := utils.GetWithTimeout(clientHubDynamic, GvrPolicy, policyName, namespace, true, DefaultTimeoutSeconds)
+		rootPlc := utils.GetWithTimeout(ClientHubDynamic, GvrPolicy, policyName, namespace, true, DefaultTimeoutSeconds)
 		var policy policiesv1.Policy
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(rootPlc.UnstructuredContent(), &policy)
 		g.ExpectWithOffset(1, err).To(BeNil())
@@ -72,12 +67,7 @@ func PatchPlacementRule(namespace, name, targetCluster, kubeconfigHub string) er
 // It assumes that the given filename (stripped of an extension) matches the
 // name of the policy, and that the PlacementRule has the same name, with '-plr'
 // appended.
-func DoCreatePolicyTest(
-	hub,
-	managed dynamic.Interface,
-	policyFile string,
-	templateGVRs ...schema.GroupVersionResource,
-) {
+func DoCreatePolicyTest(policyFile string, templateGVRs ...schema.GroupVersionResource) {
 	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
 
 	By("DoCreatePolicyTest creates " + policyFile + "on namespace" + UserNamespace)
@@ -85,15 +75,17 @@ func DoCreatePolicyTest(
 	ExpectWithOffset(1, err).To(BeNil())
 	By("DoCreatePolicyTest OcHub apply output " + output)
 
-	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, true, DefaultTimeoutSeconds)
+	plc := utils.GetWithTimeout(ClientHubDynamic, GvrPolicy, policyName, UserNamespace, true, DefaultTimeoutSeconds)
 	ExpectWithOffset(1, plc).NotTo(BeNil())
 
 	if ManuallyPatchDecisions {
 		plrName := policyName + "-plr"
 		By("Patching " + plrName + " with decision of cluster " + ClusterNamespace)
-		plr := utils.GetWithTimeout(hub, GvrPlacementRule, plrName, UserNamespace, true, DefaultTimeoutSeconds)
+		plr := utils.GetWithTimeout(
+			ClientHubDynamic, GvrPlacementRule, plrName, UserNamespace, true, DefaultTimeoutSeconds,
+		)
 		plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespace)
-		_, err := hub.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
+		_, err := ClientHubDynamic.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
 			context.TODO(),
 			plr,
 			metav1.UpdateOptions{},
@@ -103,14 +95,18 @@ func DoCreatePolicyTest(
 
 	managedPolicyName := UserNamespace + "." + policyName
 	By("Checking " + managedPolicyName + " on managed cluster in ns " + ClusterNamespace)
-	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+	mplc := utils.GetWithTimeout(
+		ClientManagedDynamic, GvrPolicy, managedPolicyName, ClusterNamespace, true, DefaultTimeoutSeconds,
+	)
 	ExpectWithOffset(1, mplc).NotTo(BeNil())
 
 	for _, tmplGVR := range templateGVRs {
 		typedName := tmplGVR.String() + "/" + policyName
 		By("Checking that the policy template " + typedName + " is present on the managed cluster")
 
-		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+		tmplPlc := utils.GetWithTimeout(
+			ClientManagedDynamic, tmplGVR, policyName, ClusterNamespace, true, DefaultTimeoutSeconds,
+		)
 		ExpectWithOffset(1, tmplPlc).NotTo(BeNil())
 	}
 }
@@ -119,7 +115,7 @@ func DoCreatePolicyTest(
 // the propagated policy was removed from the managed cluster. For each templateGVR,
 // it will check that there is no longer a policy template (for example
 // ConfigurationPolicy) of the same name on the managed cluster.
-func DoCleanupPolicy(hub, managed dynamic.Interface, policyFile string, templateGVRs ...schema.GroupVersionResource) {
+func DoCleanupPolicy(policyFile string, templateGVRs ...schema.GroupVersionResource) {
 	policyName := strings.TrimSuffix(filepath.Base(policyFile), filepath.Ext(policyFile))
 	By("Deleting " + policyFile)
 	_, err := OcHub(
@@ -128,30 +124,34 @@ func DoCleanupPolicy(hub, managed dynamic.Interface, policyFile string, template
 	)
 	Expect(err).To(BeNil())
 
-	plc := utils.GetWithTimeout(hub, GvrPolicy, policyName, UserNamespace, false, DefaultTimeoutSeconds)
+	plc := utils.GetWithTimeout(ClientHubDynamic, GvrPolicy, policyName, UserNamespace, false, DefaultTimeoutSeconds)
 	ExpectWithOffset(1, plc).To(BeNil())
 
 	managedPolicyName := UserNamespace + "." + policyName
 	By("Checking " + managedPolicyName + " was removed from managed cluster in ns " + ClusterNamespace)
-	mplc := utils.GetWithTimeout(managed, GvrPolicy, managedPolicyName, ClusterNamespace, false, DefaultTimeoutSeconds)
+	mplc := utils.GetWithTimeout(
+		ClientManagedDynamic, GvrPolicy, managedPolicyName, ClusterNamespace, false, DefaultTimeoutSeconds,
+	)
 	ExpectWithOffset(1, mplc).To(BeNil())
 
 	for _, tmplGVR := range templateGVRs {
 		typedName := tmplGVR.String() + "/" + policyName
 		By("Checking that the policy template " + typedName + " was removed from the managed cluster")
 
-		tmplPlc := utils.GetWithTimeout(managed, tmplGVR, policyName, ClusterNamespace, false, DefaultTimeoutSeconds)
+		tmplPlc := utils.GetWithTimeout(
+			ClientManagedDynamic, tmplGVR, policyName, ClusterNamespace, false, DefaultTimeoutSeconds,
+		)
 		ExpectWithOffset(1, tmplPlc).To(BeNil())
 	}
 }
 
 // DoRootComplianceTest asserts that the given policy has the given compliance
 // on the root policy on the hub cluster.
-func DoRootComplianceTest(hub dynamic.Interface, policyName string, compliance policiesv1.ComplianceState) {
+func DoRootComplianceTest(policyName string, compliance policiesv1.ComplianceState) {
 	By("Checking if the status of root policy " + policyName + " is " + string(compliance))
 	EventuallyWithOffset(
 		1,
-		GetComplianceState(hub, UserNamespace, policyName, ClusterNamespace),
+		GetComplianceState(UserNamespace, policyName, ClusterNamespace),
 		DefaultTimeoutSeconds,
 		1,
 	).Should(Equal(compliance))
@@ -159,10 +159,10 @@ func DoRootComplianceTest(hub dynamic.Interface, policyName string, compliance p
 
 // GetLatestStatusMessage returns the most recent status message for the given policy template.
 // If the policy, template, or status do not exist for any reason, an empty string is returned.
-func GetLatestStatusMessage(managed dynamic.Interface, policyName string, templateIdx int) func() string {
+func GetLatestStatusMessage(policyName string, templateIdx int) func() string {
 	return func() string {
 		replicatedPolicyName := UserNamespace + "." + policyName
-		policyInterface := managed.Resource(GvrPolicy).Namespace(ClusterNamespace)
+		policyInterface := ClientManagedDynamic.Resource(GvrPolicy).Namespace(ClusterNamespace)
 
 		policy, err := policyInterface.Get(context.TODO(), replicatedPolicyName, metav1.GetOptions{})
 		if err != nil {

--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -203,3 +203,54 @@ func GetLatestStatusMessage(policyName string, templateIdx int) func() string {
 		return message
 	}
 }
+
+// EnforcePolicy patches the root policy to be enforced, and asserts that the
+// replicated policy on the managed cluster, and policy template objects (based
+// on the provided GVRs) are enforced. Note: when checking a policy template, it
+// assumes the template's name matches the root policy's name.
+func EnforcePolicy(policyName string, templateGVRs ...schema.GroupVersionResource) {
+	ctx := context.TODO()
+	rootPolicyClient := ClientHubDynamic.Resource(GvrPolicy).Namespace(UserNamespace)
+
+	By("Patching remediationAction = enforce on root policy")
+	EventuallyWithOffset(1, func(g Gomega) {
+		rootPlc, err := rootPolicyClient.Get(ctx, policyName, metav1.GetOptions{})
+		g.ExpectWithOffset(1, err).To(BeNil())
+
+		err = unstructured.SetNestedField(rootPlc.Object, "enforce", "spec", "remediationAction")
+		g.ExpectWithOffset(1, err).To(BeNil())
+
+		_, err = rootPolicyClient.Update(ctx, rootPlc, metav1.UpdateOptions{})
+		g.ExpectWithOffset(1, err).To(BeNil())
+	}, DefaultTimeoutSeconds, 1).Should(Succeed())
+
+	managedPolicyClient := ClientManagedDynamic.Resource(GvrPolicy).Namespace(ClusterNamespace)
+
+	By("Checking that remediationAction = enforce on replicated policy")
+	EventuallyWithOffset(1, func(g Gomega) {
+		managedPlc, err := managedPolicyClient.Get(ctx, UserNamespace+"."+policyName, metav1.GetOptions{})
+		g.ExpectWithOffset(1, err).To(BeNil())
+
+		action, found, err := unstructured.NestedString(managedPlc.Object, "spec", "remediationAction")
+		g.ExpectWithOffset(1, err).To(BeNil())
+		g.ExpectWithOffset(1, found).To(BeTrue())
+		g.ExpectWithOffset(1, action).To(Equal("enforce"))
+	}, DefaultTimeoutSeconds, 1).Should(Succeed())
+
+	for _, tmplGVR := range templateGVRs {
+		typedName := tmplGVR.String() + "/" + policyName
+		By("Checking that remediationAction = enforce on policy template " + typedName)
+
+		templateClient := ClientManagedDynamic.Resource(tmplGVR).Namespace(ClusterNamespace)
+
+		EventuallyWithOffset(1, func(g Gomega) {
+			template, err := templateClient.Get(ctx, policyName, metav1.GetOptions{})
+			g.ExpectWithOffset(1, err).To(BeNil())
+
+			action, found, err := unstructured.NestedString(template.Object, "spec", "remediationAction")
+			g.ExpectWithOffset(1, err).To(BeNil())
+			g.ExpectWithOffset(1, found).To(BeTrue())
+			g.ExpectWithOffset(1, action).To(Equal("enforce"))
+		}, DefaultTimeoutSeconds, 1)
+	}
+}

--- a/test/configuration_policy_prune.go
+++ b/test/configuration_policy_prune.go
@@ -22,11 +22,10 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 	pruneTestCreatedByPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
 		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
 
-		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
-		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
@@ -38,7 +37,7 @@ func ConfigPruneBehavior(labels ...string) bool {
 			DefaultTimeoutSeconds,
 		)
 
-		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCleanupPolicy(policyYaml, GvrConfigurationPolicy)
 
 		By("Checking if the configmap was deleted")
 		utils.GetWithTimeout(
@@ -55,9 +54,9 @@ func ConfigPruneBehavior(labels ...string) bool {
 		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
 		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
 
-		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
-		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
@@ -138,11 +137,10 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 	pruneTestInformPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
 		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
 
-		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
-		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
@@ -182,7 +180,7 @@ func ConfigPruneBehavior(labels ...string) bool {
 			return remAction
 		}, DefaultTimeoutSeconds, 1).Should(MatchRegexp(".nform"))
 
-		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCleanupPolicy(policyYaml, GvrConfigurationPolicy)
 
 		By("Checking if the configmap was deleted")
 		utils.GetWithTimeout(
@@ -197,7 +195,6 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 	pruneTestEditedByPolicy := func(policyName, policyYaml string, cmShouldBeDeleted bool) {
 		clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-		clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
 
 		By("Creating the configmap before the policy")
 
@@ -225,9 +222,9 @@ func ConfigPruneBehavior(labels ...string) bool {
 			g.Expect(len(initialValue)).To(BeNumerically(">", 0))
 		}, DefaultTimeoutSeconds, 1)
 
-		DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
-		DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
 		By("Checking the configmap's data was updated")
 		Eventually(func(g Gomega) {
@@ -248,7 +245,7 @@ func ConfigPruneBehavior(labels ...string) bool {
 			g.Expect(newValue).To(Not(Equal(initialValue)))
 		}, DefaultTimeoutSeconds, 1)
 
-		DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, policyYaml, GvrConfigurationPolicy)
+		DoCleanupPolicy(policyYaml, GvrConfigurationPolicy)
 
 		By("Checking if the configmap was deleted")
 		utils.GetWithTimeout(

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -21,10 +21,10 @@ var _ = Describe("Test cert policy", func() {
 		const certPolicyName string = "cert-policy"
 		const certPolicyYaml string = "../resources/cert_policy/cert-policy.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, certPolicyYaml, common.GvrCertPolicy)
+			common.DoCreatePolicyTest(certPolicyYaml, common.GvrCertPolicy)
 		})
 		It("the policy should be compliant as there is no certificate", func() {
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a certficate that expires", func() {
 			By("Creating ../resources/cert_policy/issuer.yaml in ns default")
@@ -34,7 +34,7 @@ var _ = Describe("Test cert policy", func() {
 			_, err = common.OcManaged("apply", "-f", "../resources/cert_policy/certificate.yaml", "-n", "default")
 			Expect(err).To(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate that doesn't expire", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -44,7 +44,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a certficate that expires "+
 			"and then is compliant after a fix", func() {
@@ -55,7 +55,7 @@ var _ = Describe("Test cert policy", func() {
 			_, err = common.OcManaged("apply", "-f", "../resources/cert_policy/certificate.yaml", "-n", "default")
 			Expect(err).To(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
 			_, err = common.OcManaged(
@@ -64,7 +64,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a CA certficate that expires", func() {
 			By("Creating ../resources/cert_policy/issuer.yaml in ns default")
@@ -77,7 +77,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate that doesn't expire after CA expired", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -87,7 +87,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a certficate that has too long duration", func() {
 			By("Creating ../resources/cert_policy/issuer.yaml in ns default")
@@ -96,7 +96,7 @@ var _ = Describe("Test cert policy", func() {
 			By("Creating ../resources/cert_policy/certificate_long.yaml in ns default")
 			_, err = common.OcManaged("apply", "-f", "../resources/cert_policy/certificate_long.yaml", "-n", "default")
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate with an expected duration", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -106,7 +106,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a CA certficate that has too long duration", func() {
 			By("Creating ../resources/cert_policy/issuer.yaml in ns default")
@@ -119,7 +119,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate with an expected duration after CA", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -129,7 +129,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a certficate "+
 			"that has a DNS entry that is not allowed", func() {
@@ -143,7 +143,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate with allowed dns names", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -153,7 +153,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating a certficate with a disallowed wildcard", func() {
 			By("Creating ../resources/cert_policy/issuer.yaml in ns default")
@@ -166,7 +166,7 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after creating a certficate with no dns names that are not allowed", func() {
 			By("Creating ../resources/cert_policy/certificate_compliant.yaml in ns default")
@@ -176,10 +176,10 @@ var _ = Describe("Test cert policy", func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, certPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, certPolicyYaml, common.GvrCertPolicy)
+			common.DoCleanupPolicy(certPolicyYaml, common.GvrCertPolicy)
 
 			By("Deleting ../resources/cert_policy/issuer.yaml in ns default")
 			_, err := common.OcManaged(

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -106,23 +106,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after enforcing it", func() {
-			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(
-				clientHubDynamic,
-				common.GvrPolicy,
-				rolePolicyName,
-				userNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, _ = clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-				context.TODO(),
-				rootPlc,
-				metav1.UpdateOptions{},
-			)
-			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
-
+			common.EnforcePolicy(rolePolicyName, common.GvrConfigurationPolicy)
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("should recreate the role if manually deleted", func() {
@@ -263,23 +247,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after enforcing it", func() {
-			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(
-				clientHubDynamic,
-				common.GvrPolicy,
-				rolePolicyName,
-				userNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			rootPlc, _ = clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-				context.TODO(),
-				rootPlc,
-				metav1.UpdateOptions{},
-			)
-			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
-
+			common.EnforcePolicy(rolePolicyName, common.GvrConfigurationPolicy)
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should remove the role on managed cluster if manually created", func() {
@@ -409,39 +377,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be compliant after enforcing it", func() {
-			By("Patching remediationAction = enforce on root policy")
-			rootPlc := utils.GetWithTimeout(
-				clientHubDynamic,
-				common.GvrPolicy,
-				rolePolicyName,
-				userNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-				context.TODO(),
-				rootPlc,
-				metav1.UpdateOptions{},
-			)
-			Expect(err).To(BeNil())
-			Eventually(func() interface{} {
-				rootPlc := utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					rolePolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-				remediation, ok := rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-				if !ok {
-					return nil
-				}
-
-				return remediation
-			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual("enforce"))
-
+			common.EnforcePolicy(rolePolicyName, common.GvrConfigurationPolicy)
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be created by policy", func() {

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -21,15 +21,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-musthave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-musthave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be noncompliant", func() {
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after manually creating the role that matches", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -39,7 +34,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after removing the role", func() {
 			By("Deleting the role in default namespace on managed cluster")
@@ -49,7 +44,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default", "--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after manually creating a role that more", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -59,7 +54,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after manually creating a role that has less rule", func() {
 			By("Creating the mismatch role in default namespace on managed cluster")
@@ -69,7 +64,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after manually creating the role that matches", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -79,7 +74,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after removing the role", func() {
 			By("Deleting the role in default namespace on managed cluster")
@@ -90,15 +85,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			)
 			Expect(err).To(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
@@ -110,15 +100,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-musthave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-musthave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be noncompliant", func() {
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
@@ -138,7 +123,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			)
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("should recreate the role if manually deleted", func() {
 			By("Deleting the role in default namespace on managed cluster")
@@ -159,7 +144,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return role
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should not be patched after manually creating a role that has more rules", func() {
 			By("Creating the mismatch role in default namespace on managed cluster")
@@ -184,7 +169,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return managedRole.Object["rules"]
 			}, 30, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be patched after manually creating a role that has less rules", func() {
 			By("Creating the mismatch role in default namespace on managed cluster")
@@ -209,16 +194,11 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
@@ -230,15 +210,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-mustnothave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-mustnothave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be compliant", func() {
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after manually creating the role on managed cluster", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -248,7 +223,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after removing the role", func() {
 			By("Deleting the role in default namespace on managed cluster")
@@ -257,15 +232,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
@@ -277,15 +247,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-mustnothave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-mustnothave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be compliant", func() {
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after manually creating the role on managed cluster", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -295,7 +260,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"-n", "default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
@@ -315,7 +280,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			)
 			Expect(rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]).To(Equal("enforce"))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should remove the role on managed cluster if manually created", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -336,15 +301,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return role
 			}, defaultTimeoutSeconds, 1).Should(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
@@ -356,15 +316,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-mustonlyhave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-mustonlyhave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be noncompliant", func() {
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant if manually created", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -376,7 +331,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be noncompliant if mismatch", func() {
 			By("Creating a role with different rules")
@@ -388,7 +343,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant if matches", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -400,7 +355,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant if has less rules", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -412,7 +367,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant if matches", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -424,7 +379,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant if has more rules", func() {
 			By("Creating the role in default namespace on managed cluster")
@@ -436,15 +391,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				"default",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
@@ -456,12 +406,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 		const rolePolicyName string = "role-policy-mustonlyhave"
 		const rolePolicyYaml string = "../resources/configuration_policy/role-policy-mustonlyhave.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCreatePolicyTest(rolePolicyYaml, common.GvrConfigurationPolicy)
 		})
 		It("the policy should be compliant after enforcing it", func() {
 			By("Patching remediationAction = enforce on root policy")
@@ -497,7 +442,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return remediation
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual("enforce"))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be created by policy", func() {
 			By("Checking if the role has been created")
@@ -530,7 +475,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return role
 			}, defaultTimeoutSeconds, 1).ShouldNot(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be patched if has less rules", func() {
 			By("Creating a role with less rules")
@@ -554,7 +499,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be patched if has more rules", func() {
 			By("Creating a role with more rules")
@@ -581,7 +526,7 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		It("the role should be patched if mismatch", func() {
 			By("Creating a role with different rules")
@@ -606,15 +551,10 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 				return managedRole.Object["rules"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlRole.Object["rules"]))
 
-			common.DoRootComplianceTest(clientHubDynamic, rolePolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(
-				clientHubDynamic,
-				clientManagedDynamic,
-				rolePolicyYaml,
-				common.GvrConfigurationPolicy,
-			)
+			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,6 +40,7 @@ func TestE2e(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
+	common.InitFlags(nil)
 }
 
 var _ = test.ConfigPruneBehavior()
@@ -48,16 +49,18 @@ var _ = test.TemplateSyncErrors()
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
+	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged)
+
 	kubeconfigHub = common.KubeconfigHub
 	kubeconfigManaged = common.KubeconfigManaged
 	userNamespace = common.UserNamespace
 	clusterNamespace = common.ClusterNamespace
 	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
 
-	clientHub = common.NewKubeClient("", kubeconfigHub, "")
-	clientHubDynamic = common.NewKubeClientDynamic("", kubeconfigHub, "")
-	clientManaged = common.NewKubeClient("", kubeconfigManaged, "")
-	clientManagedDynamic = common.NewKubeClientDynamic("", kubeconfigManaged, "")
+	clientHub = common.ClientHub
+	clientHubDynamic = common.ClientHubDynamic
+	clientManaged = common.ClientManaged
+	clientManagedDynamic = common.ClientManagedDynamic
 
 	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()

--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Test gatekeeper", Ordered, func() {
 	Describe("Test gatekeeper operator", func() {
 		const GKOPolicyName string = "policy-gatekeeper-operator"
 		It("gatekeeper operator policy should be created on managed", func() {
-			common.DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, GKOPolicyYaml)
+			common.DoCreatePolicyTest(GKOPolicyYaml)
 		})
 		It("should create gatekeeper pods on managed cluster", func() {
 			By("Checking number of pods in gatekeeper-system ns")

--- a/test/e2e/hub_templates_encryption_test.go
+++ b/test/e2e/hub_templates_encryption_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 			_, err = common.OcHub("apply", "-f", configMapYAML, "-n", userNamespace)
 			Expect(err).To(BeNil())
 
-			common.DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, policyYAML, common.GvrConfigurationPolicy)
+			common.DoCreatePolicyTest(policyYAML, common.GvrConfigurationPolicy)
 		})
 
 		It("Should be compliant after enforcing it", FlakeAttempts(3), func() {
@@ -64,7 +64,7 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 			)
 			Expect(err).To(BeNil())
 
-			common.DoRootComplianceTest(clientHubDynamic, policyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(policyName, policiesv1.Compliant)
 		})
 
 		It("Should use encryption in the replicated policy", func() {

--- a/test/e2e/hub_templates_encryption_test.go
+++ b/test/e2e/hub_templates_encryption_test.go
@@ -53,17 +53,8 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 			common.DoCreatePolicyTest(policyYAML, common.GvrConfigurationPolicy)
 		})
 
-		It("Should be compliant after enforcing it", FlakeAttempts(3), func() {
-			By("Patching remediationAction=enforce on the root policy")
-			rootPlc := utils.GetWithTimeout(
-				clientHubDynamic, common.GvrPolicy, policyName, userNamespace, true, defaultTimeoutSeconds,
-			)
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-				ctx, rootPlc, metav1.UpdateOptions{},
-			)
-			Expect(err).To(BeNil())
-
+		It("Should be compliant after enforcing it", func() {
+			common.EnforcePolicy(policyName, common.GvrConfigurationPolicy)
 			common.DoRootComplianceTest(policyName, policiesv1.Compliant)
 		})
 

--- a/test/e2e/iam_policy_test.go
+++ b/test/e2e/iam_policy_test.go
@@ -15,16 +15,16 @@ var _ = Describe("Test iam policy", func() {
 		const iamPolicyName string = "iam-policy"
 		const iamPolicyYaml string = "../resources/iam_policy/iam-policy.yaml"
 		It("should be created on managed cluster", func() {
-			common.DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, iamPolicyYaml, common.GvrIamPolicy)
+			common.DoCreatePolicyTest(iamPolicyYaml, common.GvrIamPolicy)
 		})
 		It("the policy should be compliant as there is no clusterrolebindings", func() {
-			common.DoRootComplianceTest(clientHubDynamic, iamPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(iamPolicyName, policiesv1.Compliant)
 		})
 		It("the policy should be noncompliant after creating clusterrolebindings", func() {
 			By("Creating ../resources/iam_policy/clusterrolebinding.yaml")
 			_, err := common.OcManaged("apply", "-f", "../resources/iam_policy/clusterrolebinding.yaml")
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, iamPolicyName, policiesv1.NonCompliant)
+			common.DoRootComplianceTest(iamPolicyName, policiesv1.NonCompliant)
 		})
 		It("the policy should be compliant again after delete clusterrolebindings", func() {
 			By("Deleting ../resources/iam_policy/clusterrolebinding.yaml")
@@ -34,10 +34,10 @@ var _ = Describe("Test iam policy", func() {
 				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
-			common.DoRootComplianceTest(clientHubDynamic, iamPolicyName, policiesv1.Compliant)
+			common.DoRootComplianceTest(iamPolicyName, policiesv1.Compliant)
 		})
 		AfterAll(func() {
-			common.DoCleanupPolicy(clientHubDynamic, clientManagedDynamic, iamPolicyYaml, common.GvrIamPolicy)
+			common.DoCleanupPolicy(iamPolicyYaml, common.GvrIamPolicy)
 		})
 	})
 })

--- a/test/e2e/policySet_e2e_test.go
+++ b/test/e2e/policySet_e2e_test.go
@@ -107,17 +107,7 @@ var _ = Describe("Test policy set", func() {
 		})
 
 		It("Should update to compliant if all its child policy violations have been remediated", func() {
-			By("Enforcing the policy to make it compliant")
-			rootPlc := utils.GetWithTimeout(
-				clientHubDynamic, common.GvrPolicy, testPolicyName, userNamespace, true, defaultTimeoutSeconds,
-			)
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-				context.TODO(),
-				rootPlc,
-				metav1.UpdateOptions{},
-			)
-			Expect(err).To(BeNil())
+			common.EnforcePolicy(testPolicyName)
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-5.yaml")

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	clientManagedDynamic = common.ClientManagedDynamic
 
 	getComplianceState = func(policyName string) func(Gomega) interface{} {
-		return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
+		return common.GetComplianceState(userNamespace, policyName, clusterNamespace)
 	}
 
 	By("Create Namespace if needed")

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -42,7 +42,6 @@ var (
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
 
-	getComplianceState                      func(policyName string) func(Gomega) interface{}
 	canCreateOpenshiftNamespacesInitialized bool
 	canCreateOpenshiftNamespacesResult      bool
 )
@@ -72,10 +71,6 @@ var _ = BeforeSuite(func() {
 	clientHubDynamic = common.ClientHubDynamic
 	clientManaged = common.ClientManaged
 	clientManagedDynamic = common.ClientManagedDynamic
-
-	getComplianceState = func(policyName string) func(Gomega) interface{} {
-		return common.GetComplianceState(userNamespace, policyName, clusterNamespace)
-	}
 
 	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -55,20 +55,23 @@ func TestIntegration(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
+	common.InitFlags(nil)
 }
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
+	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged)
+
 	kubeconfigHub = common.KubeconfigHub
 	kubeconfigManaged = common.KubeconfigManaged
 	userNamespace = common.UserNamespace
 	clusterNamespace = common.ClusterNamespace
 	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
 
-	clientHub = common.NewKubeClient("", kubeconfigHub, "")
-	clientHubDynamic = common.NewKubeClientDynamic("", kubeconfigHub, "")
-	clientManaged = common.NewKubeClient("", kubeconfigManaged, "")
-	clientManagedDynamic = common.NewKubeClientDynamic("", kubeconfigManaged, "")
+	clientHub = common.ClientHub
+	clientHubDynamic = common.ClientHubDynamic
+	clientManaged = common.ClientManaged
+	clientManagedDynamic = common.ClientManagedDynamic
 
 	getComplianceState = func(policyName string) func(Gomega) interface{} {
 		return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -100,7 +100,7 @@ var _ = Describe(
 		It("stable/"+policyCertificateName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyCertificateName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyCertificateName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))
@@ -143,7 +143,7 @@ var _ = Describe(
 		It("stable/"+policyCertificateName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyCertificateName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyCertificateName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -72,9 +72,7 @@ var _ = Describe(
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyCertificateName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyCertificateName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyCertificateName + " exists on the Hub cluster")
@@ -100,7 +98,7 @@ var _ = Describe(
 		It("stable/"+policyCertificateName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyCertificateName, clusterNamespace),
+				common.GetComplianceState(policyCertificateName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))
@@ -143,7 +141,7 @@ var _ = Describe(
 		It("stable/"+policyCertificateName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyCertificateName, clusterNamespace),
+				common.GetComplianceState(policyCertificateName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -62,12 +62,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace,
-				"placement-"+scanPolicyName,
-				clusterNamespace,
-				kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+scanPolicyName)
 			Expect(err).To(BeNil())
 
 			By("Checking policy on hub cluster in ns " + userNamespace)
@@ -366,7 +361,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 		}
 
 		// Assign this here to avoid using nil pointers as arguments
-		getComplianceState = common.GetComplianceState(userNamespace, compPolicyName, clusterNamespace)
+		getComplianceState = common.GetComplianceState(compPolicyName)
 	})
 	Describe("Test stable/"+compPolicyName, Label("BVT"), func() {
 		It("stable/"+compPolicyName+" should be created on hub", func() {
@@ -379,12 +374,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 			)
 			Expect(err).To(BeNil())
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace,
-				"placement-"+compPolicyName,
-				clusterNamespace,
-				kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+compPolicyName)
 			Expect(err).To(BeNil())
 			By("Checking " + compPolicyName + " on hub cluster in ns " + userNamespace)
 			rootPlc := utils.GetWithTimeout(

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -366,11 +366,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 		}
 
 		// Assign this here to avoid using nil pointers as arguments
-		getComplianceState = common.GetComplianceState(
-			clientHubDynamic,
-			userNamespace,
-			compPolicyName,
-			clusterNamespace)
+		getComplianceState = common.GetComplianceState(userNamespace, compPolicyName, clusterNamespace)
 	})
 	Describe("Test stable/"+compPolicyName, Label("BVT"), func() {
 		It("stable/"+compPolicyName+" should be created on hub", func() {

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -88,50 +88,8 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 			)
 			Expect(managedplc).NotTo(BeNil())
 		})
-		It("Enforcing stable/"+scanPolicyName+"", func() {
-			Eventually(func() interface{} {
-				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					scanPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-					context.TODO(),
-					rootPlc,
-					metav1.UpdateOptions{},
-				)
-				Expect(err).To(BeNil())
-
-				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					scanPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
-			By("Checking if remediationAction is enforce for replicated policy")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(
-					clientManagedDynamic,
-					common.GvrPolicy,
-					userNamespace+"."+scanPolicyName,
-					clusterNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
+		It("Enforcing stable/"+scanPolicyName, func() {
+			common.EnforcePolicy(scanPolicyName)
 		})
 		It("ComplianceSuite "+scanName+" should be created", func() {
 			By("Checking if ComplianceSuite " + scanName + " exists on managed cluster")
@@ -404,48 +362,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 			Eventually(getComplianceState, defaultTimeoutSeconds*2, 1).Should(Equal(policiesv1.NonCompliant))
 		})
 		It("Enforcing stable/"+compPolicyName, func() {
-			Eventually(func() interface{} {
-				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					compPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-					context.TODO(),
-					rootPlc,
-					metav1.UpdateOptions{},
-				)
-				Expect(err).To(BeNil())
-				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					compPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
-			By("Checking if remediationAction is enforce for replicated policy")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(
-					clientManagedDynamic,
-					common.GvrPolicy,
-					userNamespace+"."+compPolicyName,
-					clusterNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
+			common.EnforcePolicy(compPolicyName)
 		})
 		It("Compliance operator pod should be running", func() {
 			By("Checking if pod compliance-operator has been created")

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -37,9 +37,7 @@ var _ = Describe(
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyEtcdEncryptionName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyEtcdEncryptionName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyEtcdEncryptionName + " exists on the Hub cluster")
@@ -70,7 +68,7 @@ var _ = Describe(
 		It("stable/"+policyEtcdEncryptionName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyEtcdEncryptionName, clusterNamespace),
+				common.GetComplianceState(policyEtcdEncryptionName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -70,7 +70,7 @@ var _ = Describe(
 		It("stable/"+policyEtcdEncryptionName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyEtcdEncryptionName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyEtcdEncryptionName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -85,48 +85,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 			).Should(Equal(policiesv1.NonCompliant))
 		})
 		It("Enforcing stable/policy-gatekeeper-operator", func() {
-			Eventually(func() interface{} {
-				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					gatekeeperPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-					context.TODO(),
-					rootPlc,
-					metav1.UpdateOptions{},
-				)
-				Expect(err).To(BeNil())
-				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					gatekeeperPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
-			By("Checking if remediationAction is enforce for replicated policy")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(
-					clientManagedDynamic,
-					common.GvrPolicy,
-					userNamespace+"."+gatekeeperPolicyName,
-					clusterNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
+			common.EnforcePolicy(gatekeeperPolicyName)
 		})
 		It("Gatekeeper operator pod should be running", func() {
 			By("Checking if pod gatekeeper-operator has been created")

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -27,7 +27,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 
 		// Assign this here to avoid using nil pointers as arguments
 		getComplianceState = func(policyName string) func(Gomega) interface{} {
-			return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
+			return common.GetComplianceState(userNamespace, policyName, clusterNamespace)
 		}
 	})
 	const gatekeeperPolicyURL = policyCollectStableURL +

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -18,16 +18,9 @@ import (
 )
 
 var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "BVT"), func() {
-	var getComplianceState func(policyName string) func(Gomega) interface{}
-
 	BeforeAll(func() {
 		if isOCP44() {
 			Skip("Skipping as this is ocp 4.4")
-		}
-
-		// Assign this here to avoid using nil pointers as arguments
-		getComplianceState = func(policyName string) func(Gomega) interface{} {
-			return common.GetComplianceState(userNamespace, policyName, clusterNamespace)
 		}
 	})
 	const gatekeeperPolicyURL = policyCollectStableURL +
@@ -58,12 +51,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 			)
 			Expect(err).To(BeNil())
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace,
-				"placement-"+gatekeeperPolicyName,
-				clusterNamespace,
-				kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+gatekeeperPolicyName)
 			Expect(err).To(BeNil())
 			By("Checking policy-gatekeeper-operator on hub cluster in ns " + userNamespace)
 			rootPlc := utils.GetWithTimeout(
@@ -91,7 +79,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		It("stable/policy-gatekeeper-operator should be noncompliant", func() {
 			By("Checking if the status of root policy is noncompliant")
 			Eventually(
-				getComplianceState(gatekeeperPolicyName),
+				common.GetComplianceState(gatekeeperPolicyName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -286,7 +274,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		It("stable/policy-gatekeeper-operator should be compliant", func() {
 			By("Checking if the status of root policy is compliant")
 			Eventually(
-				getComplianceState(gatekeeperPolicyName),
+				common.GetComplianceState(gatekeeperPolicyName),
 				defaultTimeoutSeconds*6,
 				10,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -52,7 +52,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 
 		// Assign this here to avoid using nil pointers as arguments
 		getComplianceState = func(policyName string) func(Gomega) interface{} {
-			return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
+			return common.GetComplianceState(userNamespace, policyName, clusterNamespace)
 		}
 	})
 	const gatekeeperPolicyURL = policyCollectCommunityURL +

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -111,48 +111,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 			).Should(Equal(policiesv1.NonCompliant))
 		})
 		It("Enforcing community/policy-gatekeeper-operator", func() {
-			Eventually(func() interface{} {
-				By("Patching remediationAction = enforce on root policy")
-				rootPlc := utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					gatekeeperPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-				rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-				_, err := clientHubDynamic.Resource(common.GvrPolicy).Namespace(userNamespace).Update(
-					context.TODO(),
-					rootPlc,
-					metav1.UpdateOptions{},
-				)
-				Expect(err).To(BeNil())
-				By("Checking if remediationAction is enforce for root policy")
-				rootPlc = utils.GetWithTimeout(
-					clientHubDynamic,
-					common.GvrPolicy,
-					gatekeeperPolicyName,
-					userNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return rootPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
-			By("Checking if remediationAction is enforce for replicated policy")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(
-					clientManagedDynamic,
-					common.GvrPolicy,
-					userNamespace+"."+gatekeeperPolicyName,
-					clusterNamespace,
-					true,
-					defaultTimeoutSeconds,
-				)
-
-				return managedPlc.Object["spec"].(map[string]interface{})["remediationAction"]
-			}, defaultTimeoutSeconds, 1).Should(Equal("enforce"))
+			common.EnforcePolicy(gatekeeperPolicyName)
 		})
 		It("Gatekeeper operator pod should be running", func() {
 			By("Checking if pod gatekeeper-operator-controller-manager has been created")

--- a/test/integration/policy_hub_templates_21440_test.go
+++ b/test/integration/policy_hub_templates_21440_test.go
@@ -98,7 +98,7 @@ var _ = Describe(
 		It(policyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, "default", policyName, clusterNamespace),
+				common.GetComplianceState("default", policyName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -26,7 +26,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	var getIAMComplianceState func(Gomega) interface{}
 	BeforeEach(func() {
 		// Assign this here to avoid using nil pointers as arguments
-		getIAMComplianceState = common.GetComplianceState(userNamespace, iamPolicyName, clusterNamespace)
+		getIAMComplianceState = common.GetComplianceState(iamPolicyName)
 	})
 
 	It("stable/"+iamPolicyName+" should be created on the hub", func() {
@@ -41,12 +41,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 		Expect(err).To(BeNil())
 
 		By("Patching the placement rule")
-		err = common.PatchPlacementRule(
-			userNamespace,
-			"placement-"+iamPolicyName,
-			clusterNamespace,
-			kubeconfigHub,
-		)
+		err = common.PatchPlacementRule(userNamespace, "placement-"+iamPolicyName)
 		Expect(err).To(BeNil())
 
 		By("Checking " + iamPolicyName + " on the hub cluster in the ns " + userNamespace)

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -26,11 +26,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	var getIAMComplianceState func(Gomega) interface{}
 	BeforeEach(func() {
 		// Assign this here to avoid using nil pointers as arguments
-		getIAMComplianceState = common.GetComplianceState(
-			clientHubDynamic,
-			userNamespace,
-			iamPolicyName,
-			clusterNamespace)
+		getIAMComplianceState = common.GetComplianceState(userNamespace, iamPolicyName, clusterNamespace)
 	})
 
 	It("stable/"+iamPolicyName+" should be created on the hub", func() {

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -38,9 +38,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 		Expect(err).To(BeNil())
 
 		By("Patching placement rule")
-		err = common.PatchPlacementRule(
-			userNamespace, "placement-"+policyIMVName, clusterNamespace, kubeconfigHub,
-		)
+		err = common.PatchPlacementRule(userNamespace, "placement-"+policyIMVName)
 		Expect(err).To(BeNil())
 
 		By("Checking that " + policyIMVName + " exists on the Hub cluster")
@@ -66,7 +64,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyIMVName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, policyIMVName, clusterNamespace),
+			common.GetComplianceState(policyIMVName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -185,7 +183,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyIMVName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, policyIMVName, clusterNamespace),
+			common.GetComplianceState(policyIMVName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyIMVName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, policyIMVName, clusterNamespace),
+			common.GetComplianceState(userNamespace, policyIMVName, clusterNamespace),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -185,7 +185,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyIMVName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, policyIMVName, clusterNamespace),
+			common.GetComplianceState(userNamespace, policyIMVName, clusterNamespace),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -204,7 +204,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		_, err := common.OcHub("apply", "-f", compliantPolicyYaml, "-n", userNamespace)
 		Expect(err).To(BeNil())
 		Eventually(
-			getComplianceState(compliantPolicyName),
+			common.GetComplianceState(compliantPolicyName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.Compliant))
@@ -228,7 +228,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric
 		_, err := common.OcHub("apply", "-f", noncompliantPolicyYaml, "-n", userNamespace)
 		Expect(err).To(BeNil())
 		Eventually(
-			getComplianceState(noncompliantPolicyName),
+			common.GetComplianceState(noncompliantPolicyName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, kyvernoInstallPolicy, localClusterName),
+			common.GetComplianceState(userNamespace, kyvernoInstallPolicy, localClusterName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -82,7 +82,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 		By("Checking if the status of the root policy is Compliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, "policy-install-kyverno", localClusterName),
+			common.GetComplianceState(userNamespace, "policy-install-kyverno", localClusterName),
 			defaultTimeoutSeconds*10,
 			1,
 		).Should(Equal(policiesv1.Compliant))
@@ -156,7 +156,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 		for name := range policyNameMap {
 			By("Checking if the status of root policy " + name + " is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, name, clusterNamespace),
+				common.GetComplianceState(userNamespace, name, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -177,7 +177,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 			By("Checking if the status of root policy " + name + " is now Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, name, clusterNamespace),
+				common.GetComplianceState(userNamespace, name, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, kyvernoInstallPolicy, localClusterName),
+			common.GetClusterComplianceState(kyvernoInstallPolicy, localClusterName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -82,7 +82,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 		By("Checking if the status of the root policy is Compliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, "policy-install-kyverno", localClusterName),
+			common.GetClusterComplianceState("policy-install-kyverno", localClusterName),
 			defaultTimeoutSeconds*10,
 			1,
 		).Should(Equal(policiesv1.Compliant))
@@ -120,9 +120,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 			Expect(err).To(BeNil())
 
 			By("Patching " + name + " placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+name, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+name)
 			Expect(err).To(BeNil())
 		}
 	})
@@ -156,7 +154,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 		for name := range policyNameMap {
 			By("Checking if the status of root policy " + name + " is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, name, clusterNamespace),
+				common.GetComplianceState(name),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -177,7 +175,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 			By("Checking if the status of root policy " + name + " is now Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, name, clusterNamespace),
+				common.GetComplianceState(name),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -96,7 +96,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 		It("stable/"+policyLimitMemoryName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyLimitMemoryName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyLimitMemoryName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -117,7 +117,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 		It("stable/"+policyLimitMemoryName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyLimitMemoryName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyLimitMemoryName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -63,9 +63,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyLimitMemoryName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyLimitMemoryName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyLimitMemoryName + " exists on the Hub cluster")
@@ -96,7 +94,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 		It("stable/"+policyLimitMemoryName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyLimitMemoryName, clusterNamespace),
+				common.GetComplianceState(policyLimitMemoryName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -117,7 +115,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 		It("stable/"+policyLimitMemoryName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyLimitMemoryName, clusterNamespace),
+				common.GetComplianceState(policyLimitMemoryName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -67,12 +67,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 		It("stable/"+policyNamespaceName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(
-					clientHubDynamic,
-					userNamespace,
-					policyNamespaceName,
-					clusterNamespace,
-				),
+				common.GetComplianceState(userNamespace, policyNamespaceName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -93,12 +88,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 		It("stable/"+policyNamespaceName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(
-					clientHubDynamic,
-					userNamespace,
-					policyNamespaceName,
-					clusterNamespace,
-				),
+				common.GetComplianceState(userNamespace, policyNamespaceName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -34,9 +34,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyNamespaceName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyNamespaceName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyNamespaceName + " exists on the Hub cluster")
@@ -67,7 +65,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 		It("stable/"+policyNamespaceName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyNamespaceName, clusterNamespace),
+				common.GetComplianceState(policyNamespaceName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -88,7 +86,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 		It("stable/"+policyNamespaceName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyNamespaceName, clusterNamespace),
+				common.GetComplianceState(policyNamespaceName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -63,9 +63,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyPodName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyPodName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyPodName + " exists on the Hub cluster")
@@ -91,7 +89,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 		It("stable/"+policyPodName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyPodName, clusterNamespace),
+				common.GetComplianceState(policyPodName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -112,7 +110,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 		It("stable/"+policyPodName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyPodName, clusterNamespace),
+				common.GetComplianceState(policyPodName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -91,7 +91,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 		It("stable/"+policyPodName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyPodName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyPodName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -112,7 +112,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 		It("stable/"+policyPodName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyPodName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyPodName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -53,12 +53,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 
 		It("stable/"+rootPolicyName+" should be created on the managed cluster", func() {
 			By("Patching placement rule placement-" + rootPolicyName)
-			err := common.PatchPlacementRule(
-				userNamespace,
-				"placement-"+rootPolicyName,
-				clusterNamespace,
-				kubeconfigHub,
-			)
+			err := common.PatchPlacementRule(userNamespace, "placement-"+rootPolicyName)
 			Expect(err).To(BeNil())
 
 			By("Checking " + rootPolicyName + " on the managed cluster in ns " + clusterNamespace)
@@ -76,7 +71,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 		It("stable/"+rootPolicyName+" should be NonCompliant", func() {
 			By("Checking the status of the root policy " + rootPolicyName + " is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(rootPolicyName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -97,7 +92,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy " + rootPolicyName + " is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(rootPolicyName),
 				defaultTimeoutSeconds*4,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -76,12 +76,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 		It("stable/"+rootPolicyName+" should be NonCompliant", func() {
 			By("Checking the status of the root policy " + rootPolicyName + " is NonCompliant")
 			Eventually(
-				common.GetComplianceState(
-					clientHubDynamic,
-					userNamespace,
-					rootPolicyName,
-					clusterNamespace,
-				),
+				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -102,12 +97,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy " + rootPolicyName + " is Compliant")
 			Eventually(
-				common.GetComplianceState(
-					clientHubDynamic,
-					userNamespace,
-					rootPolicyName,
-					clusterNamespace,
-				),
+				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
 				defaultTimeoutSeconds*4,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -278,7 +278,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 		_, err := common.OcHub("apply", "-f", noncompliantPolicyYamlReport, "-n", userNamespace)
 		Expect(err).To(BeNil())
 		Eventually(
-			getComplianceState(noncompliantPolicyNameReport),
+			common.GetComplianceState(noncompliantPolicyNameReport),
 			defaultTimeoutSeconds*8,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -311,7 +311,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Or
 		_, err := common.OcHub("apply", "-f", compliantPolicyYamlReport, "-n", userNamespace)
 		Expect(err).To(BeNil())
 		Eventually(
-			getComplianceState(compliantPolicyNameReport),
+			common.GetComplianceState(compliantPolicyNameReport),
 			defaultTimeoutSeconds*8,
 			1,
 		).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -60,9 +60,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyRoleName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyRoleName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyRoleName + " exists on the Hub cluster")
@@ -93,7 +91,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 		It("stable/"+policyRoleName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyRoleName, clusterNamespace),
+				common.GetComplianceState(policyRoleName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -114,7 +112,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 		It("stable/"+policyRoleName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyRoleName, clusterNamespace),
+				common.GetComplianceState(policyRoleName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -93,7 +93,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 		It("stable/"+policyRoleName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyRoleName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyRoleName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -114,12 +114,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 		It("stable/"+policyRoleName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(
-					clientHubDynamic,
-					userNamespace,
-					policyRoleName,
-					clusterNamespace,
-				),
+				common.GetComplianceState(userNamespace, policyRoleName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -56,9 +56,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+policyRoleBindingName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+policyRoleBindingName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + policyRoleBindingName + " exists on the Hub cluster")
@@ -84,7 +82,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 		It("stable/"+policyRoleBindingName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyRoleBindingName, clusterNamespace),
+				common.GetComplianceState(policyRoleBindingName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -105,7 +103,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 		It("stable/"+policyRoleBindingName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, policyRoleBindingName, clusterNamespace),
+				common.GetComplianceState(policyRoleBindingName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -84,7 +84,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 		It("stable/"+policyRoleBindingName+" should be NonCompliant", func() {
 			By("Checking if the status of the root policy is NonCompliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyRoleBindingName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyRoleBindingName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.NonCompliant))
@@ -105,7 +105,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 		It("stable/"+policyRoleBindingName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, policyRoleBindingName, clusterNamespace),
+				common.GetComplianceState(userNamespace, policyRoleBindingName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -64,7 +64,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))
@@ -85,7 +85,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(clientHubDynamic, userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -35,9 +35,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 			Expect(err).To(BeNil())
 
 			By("Patching placement rule")
-			err = common.PatchPlacementRule(
-				userNamespace, "placement-"+rootPolicyName, clusterNamespace, kubeconfigHub,
-			)
+			err = common.PatchPlacementRule(userNamespace, "placement-"+rootPolicyName)
 			Expect(err).To(BeNil())
 
 			By("Checking that " + rootPolicyName + " exists on the Hub cluster")
@@ -64,7 +62,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(rootPolicyName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))
@@ -85,7 +83,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 		It("stable/"+rootPolicyName+" should be Compliant", func() {
 			By("Checking if the status of the root policy is Compliant")
 			Eventually(
-				common.GetComplianceState(userNamespace, rootPolicyName, clusterNamespace),
+				common.GetComplianceState(rootPolicyName),
 				defaultTimeoutSeconds*2,
 				1,
 			).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
+	"github.com/stolostron/governance-policy-framework/test/common"
 	testcommon "github.com/stolostron/governance-policy-framework/test/common"
 )
 
@@ -127,28 +128,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 		})
 
 		It("Should update to compliant if all its child policy violations have been remediated", func() {
-			By("Enforcing the policy to make it compliant")
-			rootPlcRsrc := clientHubDynamic.Resource(testcommon.GvrPolicy)
-			var rootPlc *unstructured.Unstructured
-			Eventually(
-				func() error {
-					var err error
-					rootPlc, err = rootPlcRsrc.Namespace(userNamespace).Get(
-						context.TODO(), testPolicyName, metav1.GetOptions{},
-					)
-
-					return err
-				},
-				defaultTimeoutSeconds*2,
-				1,
-			).Should(BeNil())
-			rootPlc.Object["spec"].(map[string]interface{})["remediationAction"] = "enforce"
-			_, err := clientHubDynamic.Resource(testcommon.GvrPolicy).Namespace(userNamespace).Update(
-				context.TODO(),
-				rootPlc,
-				metav1.UpdateOptions{},
-			)
-			Expect(err).To(BeNil())
+			common.EnforcePolicy(testPolicyName)
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-3.yaml")

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -57,9 +57,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			Expect(len(templates)).Should(Equal(1))
 
 			By("Patching placement rule " + testPolicySetName + "-plr")
-			err = testcommon.PatchPlacementRule(
-				userNamespace, testPolicySetName+"-plr", clusterNamespace, kubeconfigHub,
-			)
+			err = testcommon.PatchPlacementRule(userNamespace, testPolicySetName+"-plr")
 			Expect(err).To(BeNil())
 
 			By("Checking " + testPolicyName + " on managed cluster in ns " + clusterNamespace)

--- a/test/integration/policy_zts_cmc_test.go
+++ b/test/integration/policy_zts_cmc_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace),
+			common.GetComplianceState(userNamespace, policyName, clusterNamespace),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -106,7 +106,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyName+" should be Compliant", func() {
 		By("Checking if the status of the root policy is Compliant")
 		Eventually(
-			common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace),
+			common.GetComplianceState(userNamespace, policyName, clusterNamespace),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.Compliant))

--- a/test/integration/policy_zts_cmc_test.go
+++ b/test/integration/policy_zts_cmc_test.go
@@ -45,9 +45,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 		Expect(err).To(BeNil())
 
 		By("Patching placement rule")
-		err = common.PatchPlacementRule(
-			userNamespace, "placement-"+policyName, clusterNamespace, kubeconfigHub,
-		)
+		err = common.PatchPlacementRule(userNamespace, "placement-"+policyName)
 		Expect(err).To(BeNil())
 
 		By("Checking that " + policyName + " exists on the Hub cluster")
@@ -73,7 +71,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyName+" should be NonCompliant", func() {
 		By("Checking if the status of the root policy is NonCompliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, policyName, clusterNamespace),
+			common.GetComplianceState(policyName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.NonCompliant))
@@ -106,7 +104,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	It("stable/"+policyName+" should be Compliant", func() {
 		By("Checking if the status of the root policy is Compliant")
 		Eventually(
-			common.GetComplianceState(userNamespace, policyName, clusterNamespace),
+			common.GetComplianceState(policyName),
 			defaultTimeoutSeconds*2,
 			1,
 		).Should(Equal(policiesv1.Compliant))

--- a/test/resources/policy_hub_templates_21440/policy-hub-templates-21440.yaml
+++ b/test/resources/policy_hub_templates_21440/policy-hub-templates-21440.yaml
@@ -27,11 +27,11 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-hub-templates-21440
+  name: policy-hub-templates-21440-pb
 placementRef:
   apiGroup: apps.open-cluster-management.io
   kind: PlacementRule
-  name: placement-policy-hub-templates-21440
+  name: policy-hub-templates-21440-plr
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
@@ -40,7 +40,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-hub-templates-21440
+  name: policy-hub-templates-21440-plr
 spec:
   clusterConditions:
   - status: "True"

--- a/test/template_sync_errors.go
+++ b/test/template_sync_errors.go
@@ -29,21 +29,15 @@ func TemplateSyncErrors(labels ...string) bool {
 				Expect(err).To(BeNil())
 			})
 			It("Should be noncompliant with a mapping not found status", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
-				DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, nonexistentPolicyKindYaml)
-				DoRootComplianceTest(clientHubDynamic, nonexistentPolicyKindName, policiesv1.NonCompliant)
+				DoCreatePolicyTest(nonexistentPolicyKindYaml)
+				DoRootComplianceTest(nonexistentPolicyKindName, policiesv1.NonCompliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, nonexistentPolicyKindName, 0),
+					GetLatestStatusMessage(nonexistentPolicyKindName, 0),
 					DefaultTimeoutSeconds, 1,
 				).Should(MatchRegexp(".*Mapping not found.*"))
 			})
 			It("Should become compliant when the kind is fixed", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
 				_, err := OcHub("patch", "policies.policy.open-cluster-management.io", nonexistentPolicyKindName,
 					"-n", UserNamespace, "--type=json", "-p", `[{
 						"op":"replace",
@@ -51,23 +45,20 @@ func TemplateSyncErrors(labels ...string) bool {
 						"value":"ConfigurationPolicy"
 					}]`)
 				Expect(err).To(BeNil())
-				DoRootComplianceTest(clientHubDynamic, nonexistentPolicyKindName, policiesv1.Compliant)
+				DoRootComplianceTest(nonexistentPolicyKindName, policiesv1.Compliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, nonexistentPolicyKindName, 0),
+					GetLatestStatusMessage(nonexistentPolicyKindName, 0),
 					DefaultTimeoutSeconds, 1,
 				).ShouldNot(MatchRegexp(".*Mapping not found.*"))
 			})
 			It("Should become noncompliant when the original policy is restored", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
 				_, err := OcHub("apply", "-f", nonexistentPolicyKindYaml, "-n", UserNamespace)
 				Expect(err).To(BeNil())
-				DoRootComplianceTest(clientHubDynamic, nonexistentPolicyKindName, policiesv1.NonCompliant)
+				DoRootComplianceTest(nonexistentPolicyKindName, policiesv1.NonCompliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, nonexistentPolicyKindName, 0),
+					GetLatestStatusMessage(nonexistentPolicyKindName, 0),
 					DefaultTimeoutSeconds, 1,
 				).Should(MatchRegexp(".*Mapping not found.*"))
 			})
@@ -81,21 +72,15 @@ func TemplateSyncErrors(labels ...string) bool {
 				Expect(err).To(BeNil())
 			})
 			It("Should be noncompliant and report the reason the CR is invalid", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
-				DoCreatePolicyTest(clientHubDynamic, clientManagedDynamic, invalidCRPolicyYaml)
-				DoRootComplianceTest(clientHubDynamic, invalidCRPolicyName, policiesv1.NonCompliant)
+				DoCreatePolicyTest(invalidCRPolicyYaml)
+				DoRootComplianceTest(invalidCRPolicyName, policiesv1.NonCompliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, invalidCRPolicyName, 0),
+					GetLatestStatusMessage(invalidCRPolicyName, 0),
 					DefaultTimeoutSeconds, 1,
 				).Should(MatchRegexp(".*Failed to create.*Unsupported value.*"))
 			})
 			It("Should become compliant when the spec is fixed", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
 				_, err := OcHub("patch", "policies.policy.open-cluster-management.io", invalidCRPolicyName,
 					"-n", UserNamespace, "--type=json", "-p", `[{
 						"op":"replace",
@@ -103,23 +88,20 @@ func TemplateSyncErrors(labels ...string) bool {
 						"value":"None"
 					}]`)
 				Expect(err).To(BeNil())
-				DoRootComplianceTest(clientHubDynamic, invalidCRPolicyName, policiesv1.Compliant)
+				DoRootComplianceTest(invalidCRPolicyName, policiesv1.Compliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, invalidCRPolicyName, 0),
+					GetLatestStatusMessage(invalidCRPolicyName, 0),
 					DefaultTimeoutSeconds, 1,
 				).ShouldNot(MatchRegexp(".*Failed to create.*Unsupported value.*"))
 			})
 			It("Should become noncompliant when the original policy is restored", func() {
-				clientManagedDynamic := NewKubeClientDynamic("", KubeconfigManaged, "")
-				clientHubDynamic := NewKubeClientDynamic("", KubeconfigHub, "")
-
 				_, err := OcHub("apply", "-f", invalidCRPolicyYaml, "-n", UserNamespace)
 				Expect(err).To(BeNil())
-				DoRootComplianceTest(clientHubDynamic, invalidCRPolicyName, policiesv1.NonCompliant)
+				DoRootComplianceTest(invalidCRPolicyName, policiesv1.NonCompliant)
 
 				Eventually(
-					GetLatestStatusMessage(clientManagedDynamic, invalidCRPolicyName, 0),
+					GetLatestStatusMessage(invalidCRPolicyName, 0),
 					DefaultTimeoutSeconds, 1,
 				).Should(MatchRegexp(".*Failed to update.*Unsupported value.*"))
 			})


### PR DESCRIPTION
Lots of refactors to make some of the common functions simpler. One goal was to increase readability of the tests, and to try to make more common behaviors more obvious in the future.

Some tests that enforce a policy would infrequently fail because the `Update` API call used would fail, because the object was modified before the action took place. The new common function that handles this will retry and shouldn't have those failures.