### PR TITLE
Extend login retry interval

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -113,12 +113,12 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 
 // GetComplianceState returns a function that requires no arguments that retrieves the
 // compliance state of the input policy.
-func GetComplianceState(clientHubDynamic dynamic.Interface, namespace, policyName, clusterNamespace string) func() interface{} {
-	return func() interface{} {
+func GetComplianceState(clientHubDynamic dynamic.Interface, namespace, policyName, clusterNamespace string) func(gomega.Gomega) interface{} {
+	return func(g gomega.Gomega) interface{} {
 		rootPlc := utils.GetWithTimeout(clientHubDynamic, GvrPolicy, policyName, namespace, true, DefaultTimeoutSeconds)
 		var policy policiesv1.Policy
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(rootPlc.UnstructuredContent(), &policy)
-		gomega.ExpectWithOffset(1, err).To(gomega.BeNil())
+		g.ExpectWithOffset(1, err).To(gomega.BeNil())
 		for _, statusPerCluster := range policy.Status.Status {
 			if statusPerCluster.ClusterNamespace == clusterNamespace {
 				return statusPerCluster.ComplianceState

--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -91,7 +91,7 @@ func GetKubeConfig(server, username, password string) (string, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		os.Remove(f.Name())
-		return "", fmt.Errorf("failed to login: %s", string(output))
+		return "", fmt.Errorf("failed to login with user '%s': %s", username, string(output))
 	}
 
 	return kubeconfigPath, nil

--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -60,7 +59,7 @@ func GenerateInsecurePassword() (string, error) {
 // after use.
 func GetKubeConfig(server, username, password string) (string, error) {
 	// Create a temporary file for the kubeconfig that the `oc login` command will generate
-	f, err := ioutil.TempFile("", "e2e-kubeconfig")
+	f, err := os.CreateTemp("", "e2e-kubeconfig")
 	if err != nil {
 		return "", fmt.Errorf("failed to create the temporary kubeconfig")
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -42,7 +42,7 @@ var (
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
 
-	getComplianceState                      func(policyName string) func() interface{}
+	getComplianceState                      func(policyName string) func(Gomega) interface{}
 	canCreateOpenshiftNamespacesInitialized bool
 	canCreateOpenshiftNamespacesResult      bool
 )
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	clientManaged = common.NewKubeClient("", kubeconfigManaged, "")
 	clientManagedDynamic = common.NewKubeClientDynamic("", kubeconfigManaged, "")
 
-	getComplianceState = func(policyName string) func() interface{} {
+	getComplianceState = func(policyName string) func(Gomega) interface{} {
 		return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
 	}
 

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -150,7 +150,7 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] Test compliance opera
 	const compCISScanPolicyURL = policyCollectCMURL + "policy-compliance-operator-cis-scan.yaml"
 	const compCISScanPolicyName = "policy-cis-scan"
 
-	var getComplianceState func() interface{}
+	var getComplianceState func(Gomega) interface{}
 
 	BeforeAll(func() {
 		if !isOCP46andAbove() {

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "BVT"), func() {
-	var getComplianceState func(policyName string) func() interface{}
+	var getComplianceState func(policyName string) func(Gomega) interface{}
 
 	BeforeAll(func() {
 		if isOCP44() {
@@ -27,7 +27,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 		}
 
 		// Assign this here to avoid using nil pointers as arguments
-		getComplianceState = func(policyName string) func() interface{} {
+		getComplianceState = func(policyName string) func(Gomega) interface{} {
 			return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
 		}
 	})

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -32,7 +32,7 @@ func isOCP44() bool {
 }
 
 var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
-	var getComplianceState func(policyName string) func() interface{}
+	var getComplianceState func(policyName string) func(Gomega) interface{}
 	BeforeAll(func() {
 		if isOCP44() {
 			Skip("Skipping as this is ocp 4.4")
@@ -42,7 +42,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 		}
 
 		// Assign this here to avoid using nil pointers as arguments
-		getComplianceState = func(policyName string) func() interface{} {
+		getComplianceState = func(policyName string) func(Gomega) interface{} {
 			return common.GetComplianceState(clientHubDynamic, userNamespace, policyName, clusterNamespace)
 		}
 	})

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -98,7 +98,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator in an Ap
 				return err
 			},
 			fiveMinutes,
-			1,
+			10,
 		).Should(BeNil())
 		// Delete the kubeconfig file after the test.
 		defer func() { os.Remove(kubeconfigSubAdmin) }()

--- a/test/integration/policy_iam_test.go
+++ b/test/integration/policy_iam_test.go
@@ -22,7 +22,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitclusteradmin 
 		iamPolicyManagedNamespace = "iam-policy-test"
 	)
 
-	var getIAMComplianceState func() interface{}
+	var getIAMComplianceState func(Gomega) interface{}
 	BeforeEach(func() {
 		// Assign this here to avoid using nil pointers as arguments
 		getIAMComplianceState = common.GetComplianceState(clientHubDynamic, userNamespace, iamPolicyName, clusterNamespace)

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -151,7 +151,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-imagemanifestvuln 
 				}
 				return ""
 			},
-			defaultTimeoutSeconds*2,
+			defaultTimeoutSeconds*4,
 			1,
 		).Should(Equal(string(policiesv1.Compliant)))
 


### PR DESCRIPTION
This matches the interval in `policy_generator_acm_hardening.go`. It also updates a deprecated `ioutils` function.