### PR TITLE
Use user/IDP patterns for hardening test

### DIFF
--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -90,7 +90,7 @@ func GetKubeConfig(server, username, password string) (string, error) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		os.Remove(f.Name())
+		os.Remove(kubeconfigPath)
 		return "", fmt.Errorf("failed to login with user '%s': %s", username, string(output))
 	}
 

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -58,14 +58,14 @@ func cleanup(namespace string, secret string, user common.OCPUser) {
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening generated PolicySet in an App subscription", Ordered, Label("policy-collection", "stable"), func() {
 	const namespace = "policies"
-	const secret = "grc-e2e-subscription-admin-user"
+	const secret = "grc-e2e-hardening-sub-admin-user"
 	const clustersetRoleName = "grc-e2e-clusterset-role"
 	const subAdminBinding = "open-cluster-management:subscription-admin"
 	ocpUser := common.OCPUser{
 		ClusterRoles: []types.NamespacedName{
 			{Name: "open-cluster-management:admin:local-cluster"},
 			{
-				Name:      "admin",
+				Name:      "grc-e2e-hardening-sub-admin",
 				Namespace: namespace,
 			},
 			{Name: clustersetRoleName},


### PR DESCRIPTION
The assumption in the cleanup is that the secret (and IDP) are named `<username>-user`, but the hardening test didn't follow that pattern, preventing proper cleanup.

Fingers crossed this is the cause of the intermittent subadmin issue since if the hardening tests run first (which doesn't always happen and would explain why it pops up once in a while), they would have created an IDP that wasn't properly cleaned up for the following generator tests.