### PR TITLE
remove compliance operator pod cleanup check

### DIFF
--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -137,12 +137,6 @@ func complianceScanTest(scanPolicyName string, scanPolicyUrl string, scanName st
 		utils.ListWithTimeoutByNamespace(clientManagedDynamic, common.GvrComplianceCheckResult, metav1.ListOptions{}, "openshift-compliance", 0, false, defaultTimeoutSeconds)
 		By("Wait for compliancescan to be deleted")
 		utils.ListWithTimeoutByNamespace(clientManagedDynamic, common.GvrComplianceScan, metav1.ListOptions{}, "openshift-compliance", 0, false, defaultTimeoutSeconds)
-		By("Wait for other pods to be deleted in openshift-compliance ns")
-		Eventually(func(g Gomega) interface{} {
-			podList, err := clientManaged.CoreV1().Pods("openshift-compliance").List(context.TODO(), metav1.ListOptions{})
-			g.Expect(err).To(BeNil())
-			return len(podList.Items)
-		}, defaultTimeoutSeconds*4, 1).Should(Equal(3))
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

https://github.com/stolostron/backlog/issues/25465

The failure in the issue was difficult to reproduce, which means it probably only happens occasionally, and we expect these pods to get cleaned up eventually on their own. After talking with @dhaiducek the best course of action seems to be to just remove the cleanup check, and we can address it in the future in the event the pods aren't being cleaned up properly.