### PR TITLE
Fix Gatekeeper namespace creation detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,9 @@ default::
 clean::
 	-rm bin/*
 	-rm .build-harness-bootstrap
-	-rm kubeconfig_managed
-	-rm kubeconfig_hub
+	-rm kubeconfig_$(MANAGED_CLUSTER_NAME)
+	-rm kubeconfig_$(HUB_CLUSTER_NAME)
+	-rm kubeconfig_$(HUB_CLUSTER_NAME)_internal
 	-rm -r test-output/
 	-rm -r vendor/
 

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -241,7 +241,7 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 			By("Creating invalid namespace on managed")
 			Eventually(func() interface{} {
 				out, _ := utils.KubectlWithOutput("apply", "-f", "../resources/gatekeeper/ns-create-invalid.yaml", "--kubeconfig="+kubeconfigManaged)
-				if out == "namespace/e2etestfail created" {
+				if strings.Contains(out, "namespace/e2etestfail created") {
 					GinkgoWriter.Println("Deleting created namespace to retry create:")
 					_, _ = utils.KubectlWithOutput("delete", "-f", "../resources/gatekeeper/ns-create-invalid.yaml", "--kubeconfig="+kubeconfigManaged)
 				}


### PR DESCRIPTION
There's a newline or some whitespace in there that the equality wasn't catching

Followup to:
- https://github.com/stolostron/governance-policy-framework/pull/445