### PR TITLE
Use substring for creation detection (downstream)

### DIFF
--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -228,7 +228,7 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 			By("Creating invalid namespace on managed")
 			Eventually(func() interface{} {
 				out, _ := utils.KubectlWithOutput("apply", "-f", "../resources/gatekeeper/ns-create-invalid.yaml", "--kubeconfig="+kubeconfigManaged)
-				if out == "namespace/e2etestfail created" {
+				if strings.Contains(out, "namespace/e2etestfail created") {
 					GinkgoWriter.Println("Deleting created namespace to retry create:")
 					_, _ = utils.KubectlWithOutput("delete", "-f", "../resources/gatekeeper/ns-create-invalid.yaml", "--kubeconfig="+kubeconfigManaged)
 				}


### PR DESCRIPTION
I am slightly horrified I missed the second update in the downstream gatekeeper test. I've updated the cherry-picks to include both. This is a followup to:
- #463 