### PR TITLE
Output the Gatekeeper pods when the deployment fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ KIND_MANAGED_NAMESPACE ?= open-cluster-management-agent-addon
 MANAGED_CLUSTER_NAME ?= managed
 HUB_CLUSTER_NAME ?= hub
 KIND_VERSION ?= latest
+
+# TODO: Remove this since this a workaround until the following is addressed.
+# https://github.com/stolostron/backlog/issues/25698
+ifeq ($(KIND_VERSION), latest)
+	KIND_VERSION = v1.24.4
+endif
+
 ifneq ($(KIND_VERSION), latest)
 	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
 else

--- a/test/e2e/gatekeeper_test.go
+++ b/test/e2e/gatekeeper_test.go
@@ -128,9 +128,13 @@ var _ = Describe("Test gatekeeper", Ordered, func() {
 		})
 		It("should generate statuses properly on hub, no violation expected", func() {
 			By("Checking if status for policy template policy-gatekeeper-k8srequiredlabels is compliant")
-			Eventually(func() interface{} {
+			Eventually(func(g Gomega) interface{} {
 				plc := utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, userNamespace+"."+GKPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
-				details := plc.Object["status"].(map[string]interface{})["details"].([]interface{})
+				status, ok := plc.Object["status"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+				details, ok := status["details"].([]interface{})
+				g.Expect(ok).To(BeTrue())
+
 				return details[0].(map[string]interface{})["compliant"]
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			By("Checking if violation message for policy template policy-gatekeeper-audit is compliant")


### PR DESCRIPTION
This also pins the Kubernetes version to v1.24 for the latest to workaround:
https://github.com/stolostron/backlog/issues/25698