### PR TITLE
Address possible problem with gatekeeper changing dryrun to deny

### DIFF
--- a/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_downstream_test.go
@@ -171,11 +171,13 @@ var _ = Describe("RHACM4K-3055", func() {
 		It("stable/policy-gatekeeper-sample should be created on hub", func() {
 			By("Creating policy on hub")
 			utils.KubectlWithOutput("apply", "-f", GKPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+			By("Policy should be created on hub")
+			utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			By("Patching to remove dryrun")
 			utils.KubectlWithOutput(
 				"patch", "-n", userNamespace, common.GvrPolicy.Resource+"."+common.GvrPolicy.Group, GKPolicyName,
-				"--type=json", "-p=[{\"op\":\"remove\", \"path\": "+
-					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\"}]",
+				"--type=json", "-p=[{\"op\":\"replace\", \"path\": "+
+					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\", \"value\":\"deny\"}]",
 				"--kubeconfig="+kubeconfigHub,
 			)
 			By("Patching placement rule")

--- a/test/policy-collection/policy_gatekeeper_operator_test.go
+++ b/test/policy-collection/policy_gatekeeper_operator_test.go
@@ -219,11 +219,13 @@ var _ = Describe("", func() {
 		It("community/policy-gatekeeper-sample should be created on hub", func() {
 			By("Creating policy on hub")
 			utils.KubectlWithOutput("apply", "-f", GKPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
+			By("Policy should be created on hub")
+			utils.GetWithTimeout(clientHubDynamic, common.GvrPolicy, GKPolicyName, userNamespace, true, defaultTimeoutSeconds)
 			By("Patching to remove dryrun")
 			utils.KubectlWithOutput(
 				"patch", "-n", userNamespace, common.GvrPolicy.Resource+"."+common.GvrPolicy.Group, GKPolicyName,
-				"--type=json", "-p=[{\"op\":\"remove\", \"path\": "+
-					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\"}]",
+				"--type=json", "-p=[{\"op\":\"replace\", \"path\": "+
+					"\"/spec/policy-templates/0/objectDefinition/spec/object-templates/1/objectDefinition/spec/enforcementAction\", \"value\":\"deny\"}]",
 				"--kubeconfig="+kubeconfigHub,
 			)
 			By("Patching placement rule")


### PR DESCRIPTION
A canary test failure that I think may be due to a missing change in the 2.4 release.  Linking the canary issue and the related PR below.

Refs:
 - https://github.com/stolostron/backlog/issues/25851
 - https://github.com/stolostron/governance-policy-framework/pull/286

Signed-off-by: Gus Parvin <gparvin@redhat.com>