### PR TITLE
Add some gatekeeper debugging that may help figure out canary failure

### DIFF
--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -418,6 +418,13 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 	})
 
 	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			common.OutputDebugInfo(
+				"Gatekeeper policies",
+				kubeconfigHub,
+				"constrainttemplates.templates.gatekeeper.sh",
+			)
+		}
 		// Clean up mutation policies
 		utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 		Eventually(func() interface{} {

--- a/test/integration/policy_gatekeeper_operator_test.go
+++ b/test/integration/policy_gatekeeper_operator_test.go
@@ -431,6 +431,13 @@ var _ = Describe("", Ordered, Label("policy-collection", "community"), func() {
 	})
 
 	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			common.OutputDebugInfo(
+				"Gatekeeper policies",
+				kubeconfigHub,
+				"constrainttemplates.templates.gatekeeper.sh",
+			)
+		}
 		// Clean up mutation policies
 		utils.KubectlWithOutput("delete", "-f", GKAssignMetadataPolicyYaml, "-n", userNamespace, "--kubeconfig="+kubeconfigHub)
 		Eventually(func() interface{} {


### PR DESCRIPTION
Without finding a real root cause for a gatekeeper canary failure I'm hoping adding some debugging logs may help get us closer to figuring out what may have broken. I think for now we will focus on the hub side policies to make sure patches applied at runtime are working.

Refs:
 - https://github.com/stolostron/backlog/issues/25903

Signed-off-by: Gus Parvin <gparvin@redhat.com>