### PR TITLE
Require the SONAR_TOKEN secret in the sonarcloud reusable workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,9 @@ name: SonarCloud scan
 
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
Relates:
https://github.com/stolostron/backlog/issues/25949