### PR TITLE
Set the branch name on pushes for SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,6 +64,11 @@ jobs:
           echo "sonar.pullrequest.key=$(jq -r .pull_request.number event.json)" >> sonar-project.properties
           echo "sonar.pullrequest.branch=$(jq -r .pull_request.head.ref event.json)" >> sonar-project.properties
 
+      - name: Set the push properties in SonarCloud
+        if: github.event.workflow_run.event == 'push'
+        run: |
+          echo "sonar.branch.name=$(jq -r '.ref | split("/")[-1]' event.json)" >> sonar-project.properties
+
       - name: Set additional properties in SonarCloud
         run: |
           echo "sonar.scm.revision=${{ github.event.workflow_run.head_commit.id }}" >> sonar-project.properties


### PR DESCRIPTION
Without it, SonarCloud seems to assume things are happening on `main`.