### PR TITLE
Add remote Kustomize generator E2E tests

### DIFF
--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -1,0 +1,155 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GitOpsUserSetup configures a new user to use for the GitOps deployments.
+// The provided namespace is deleted and recreated as part of the setup.
+// It returns the OCPUser instance, which contains a path to the created kubeconfig file.
+func GitOpsUserSetup(
+	namespace string, username string, additionalRoles ...types.NamespacedName,
+) OCPUser {
+	const subAdminBinding = "open-cluster-management:subscription-admin"
+
+	ocpUser := OCPUser{
+		ClusterRoles: []types.NamespacedName{
+			{Name: "open-cluster-management:admin:local-cluster"},
+			{
+				Name:      "admin",
+				Namespace: namespace,
+			},
+		},
+		ClusterRoleBindings: []string{subAdminBinding},
+		Password:            "",
+		Username:            username,
+	}
+
+	// Append any additional provided ClusterRoles
+	ocpUser.ClusterRoles = append(ocpUser.ClusterRoles, additionalRoles...)
+
+	// Occasionally, the subscription-admin ClusterRoleBinding may not exist due to some unknown
+	// error. This ClusterRoleBinding is supposed to have been created by the App Lifecycle
+	// controllers. In this unusual case, create the ClusterRoleBinding based on the advice from
+	// the Application Lifecycle squad.
+	subAdminBindingObj := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: subAdminBinding,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     subAdminBinding,
+		},
+	}
+
+	By("Verifying that the subscription-admin ClusterRoleBinding exists")
+
+	_, err := ClientHub.RbacV1().ClusterRoleBindings().Create(
+		context.TODO(), &subAdminBindingObj, metav1.CreateOptions{},
+	)
+	if err != nil {
+		ExpectWithOffset(1, k8serrors.IsAlreadyExists(err)).Should(
+			BeTrue(),
+			"Expected error to be 'already exists': "+fmt.Sprint(err),
+		)
+	}
+
+	By("Cleaning up any existing subscription-admin user config")
+	GitOpsCleanup(namespace, ocpUser)
+
+	By("Creating a subscription-admin user and configuring IDP")
+	// Create a namespace to house the subscription configuration.
+	nsObj := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err = ClientHub.CoreV1().Namespaces().Create(
+		context.TODO(), &nsObj, metav1.CreateOptions{},
+	)
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	// Create the OpenShift user that can be used for logging in.
+	ocpUser.Password, err = GenerateInsecurePassword()
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	err = CreateOCPUser(ClientHub, ClientHubDynamic, ocpUser)
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	// Get a kubeconfig logged in as the subscription and local-cluster administrator OpenShift
+	// user.
+	hubServerURL, err := OcHub("whoami", "--show-server=true")
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	hubServerURL = strings.TrimSuffix(hubServerURL, "\n")
+	// Use eventually since it can take a while for OpenShift to configure itself with the new
+	// identity provider (IDP).
+	const fiveMinutes = 5 * 60
+
+	EventuallyWithOffset(1,
+		func() error {
+			var err error
+			ocpUser.Kubeconfig, err = GetKubeConfig(
+				hubServerURL, ocpUser.Username, ocpUser.Password,
+			)
+
+			return err
+		},
+		fiveMinutes,
+		10,
+	).Should(BeNil())
+
+	return ocpUser
+}
+
+// GitOpsCleanup will remove any test data/configuration on the OpenShift cluster that was added/updated
+// as part of the GitOps test. The kubeconfig file is also deleted from the filesystem. Any errors will
+// be propagated as gomega failed assertions.
+func GitOpsCleanup(namespace string, user OCPUser) {
+	// Delete kubeconfig file if it is specified
+	if user.Kubeconfig != "" {
+		err := os.Remove(user.Kubeconfig)
+		ExpectWithOffset(1, err).Should(BeNil())
+	}
+
+	err := ClientHub.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+	if !k8serrors.IsNotFound(err) {
+		ExpectWithOffset(1, err).Should(BeNil())
+	}
+
+	// Wait for the namespace to be fully deleted before proceeding.
+	EventuallyWithOffset(1,
+		func() bool {
+			_, err := ClientHub.CoreV1().Namespaces().Get(
+				context.TODO(), namespace, metav1.GetOptions{},
+			)
+			isNotFound := k8serrors.IsNotFound(err)
+			if !isNotFound && err != nil {
+				GinkgoWriter.Printf("'%s' namespace 'get' error: %w", err)
+			}
+
+			return isNotFound
+		},
+		DefaultTimeoutSeconds,
+		1,
+	).Should(BeTrue())
+
+	err = CleanupOCPUser(ClientHub, ClientHubDynamic, user)
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	err = ClientHub.CoreV1().Secrets("openshift-config").Delete(context.TODO(), user.Username, metav1.DeleteOptions{})
+	if !k8serrors.IsNotFound(err) {
+		ExpectWithOffset(1, err).Should(BeNil())
+	}
+}

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -69,8 +69,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			},
 			{Name: clustersetRoleName},
 		},
-		// To be considered a subscription-admin you must be part of this cluster role binding.
-		// Having the proper role in another cluster role binding does not work.
 		ClusterRoleBindings: []string{subAdminBinding},
 		Password:            "",
 		Username:            "grc-e2e-hardening-sub-admin",
@@ -182,7 +180,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			"--kubeconfig="+kubeconfigSubAdmin,
 		)
 		Expect(err).Should(BeNil())
+	})
 
+	It("Validates the propagated policies", func() {
 		By("Checking that the policy set was created")
 		policySetRsrc := clientHubDynamic.Resource(common.GvrPolicySet)
 		var policyset *unstructured.Unstructured

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -4,18 +4,11 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
@@ -24,98 +17,21 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"with a remote Kustomize directory", Ordered, Label("SVT"), func() {
 	const policyName = "e2e-grc-remote-policy-app"
 	const namespace = "grc-e2e-remote-policy-generator"
-	const secret = "grc-e2e-subscription-admin-user"
-	const subAdminBinding = "open-cluster-management:subscription-admin"
-	ocpUser := common.OCPUser{
-		ClusterRoles: []types.NamespacedName{
-			{Name: "open-cluster-management:admin:local-cluster"},
-			{
-				Name:      "admin",
-				Namespace: namespace,
-			},
-		},
-		ClusterRoleBindings: []string{subAdminBinding},
-		Password:            "",
-		Username:            "grc-e2e-subscription-admin",
-	}
+	const username = "grc-e2e-subadmin-user-remotepolgen"
+	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
-		By("Verifying that the subscription-admin ClusterRoleBinding exists")
-		// Occasionally, the subscription-admin ClusterRoleBinding may not exist due to some unknown
-		// error. This ClusterRoleBinding is supposed to have been created by the App Lifecycle
-		// controllers. In this unusual case, create the ClusterRoleBinding based on the advice from
-		// the Application Lifecycle squad.
-		subAdminBindingObj := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: subAdminBinding,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     subAdminBinding,
-			},
-		}
-		_, err := clientHub.RbacV1().ClusterRoleBindings().Create(
-			context.TODO(), &subAdminBindingObj, metav1.CreateOptions{},
-		)
-		if err != nil {
-			Expect(k8serrors.IsAlreadyExists(err)).Should(
-				BeTrue(),
-				"Expected error to be 'already exists': "+fmt.Sprint(err),
-			)
-		}
-
-		By("Cleaning up any existing subscription-admin user config")
-		cleanup(namespace, secret, ocpUser)
-
-		By("Creating a subscription-admin user and configuring IDP")
-		// Create a namespace to house the subscription configuration.
-		nsObj := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		_, err = clientHub.CoreV1().Namespaces().Create(
-			context.TODO(), &nsObj, metav1.CreateOptions{},
-		)
-		Expect(err).Should(BeNil())
-
-		// Create a subscription and local-cluster administrator OpenShift user that can be used
-		// for logging in.
-		userPassword, err := common.GenerateInsecurePassword()
-		Expect(err).Should(BeNil())
-		ocpUser.Password = userPassword
-		err = common.CreateOCPUser(clientHub, clientHubDynamic, secret, ocpUser)
-		Expect(err).Should(BeNil())
-
-		// Get a kubeconfig logged in as the subscription and local-cluster administrator OpenShift
-		// user.
-		hubServerURL, err := common.OcHub("whoami", "--show-server=true")
-		Expect(err).Should(BeNil())
-		hubServerURL = strings.TrimSuffix(hubServerURL, "\n")
-		// Use eventually since it can take a while for OpenShift to configure itself with the new
-		// identity provider (IDP).
-		var kubeconfigSubAdmin string
-		const fiveMinutes = 5 * 60
-		Eventually(
-			func() error {
-				var err error
-				kubeconfigSubAdmin, err = common.GetKubeConfig(
-					hubServerURL, ocpUser.Username, ocpUser.Password,
-				)
-
-				return err
-			},
-			fiveMinutes,
-			10,
-		).Should(BeNil())
-		// Delete the kubeconfig file after the test.
-		defer func() { os.Remove(kubeconfigSubAdmin) }()
+		By("Creating and setting up the GitOps user")
+		ocpUser = common.GitOpsUserSetup(namespace, username)
 
 		By("Creating the application subscription")
-		_, err = common.OcHub(
+		_, err := common.OcUser(
+			ocpUser,
 			"apply",
 			"-f",
 			"../resources/policy_generator/subscription-remote.yaml",
 			"-n",
 			namespace,
-			"--kubeconfig="+kubeconfigSubAdmin,
 		)
 		Expect(err).Should(BeNil())
 	})
@@ -192,6 +108,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 
 	AfterAll(func() {
 		By("Cleaning up the changes made to the cluster in the test")
-		cleanup(namespace, secret, ocpUser)
+		common.GitOpsCleanup(namespace, ocpUser)
 	})
 })

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -34,8 +34,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 				Namespace: namespace,
 			},
 		},
-		// To be considered a subscription-admin you must be part of this cluster role binding.
-		// Having the proper role in another cluster role binding does not work.
 		ClusterRoleBindings: []string{subAdminBinding},
 		Password:            "",
 		Username:            "grc-e2e-subscription-admin",
@@ -120,7 +118,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			"--kubeconfig="+kubeconfigSubAdmin,
 		)
 		Expect(err).Should(BeNil())
+	})
 
+	It("Validates the propagated policies", func() {
 		// Perform some basic validation on the generated policy.
 		By("Checking that the root policy was created")
 		policyRsrc := clientHubDynamic.Resource(common.GvrPolicy)

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -1,0 +1,197 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
+)
+
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
+	"with a remote Kustomize directory", Ordered, Label("SVT"), func() {
+	const policyName = "e2e-grc-remote-policy-app"
+	const namespace = "grc-e2e-remote-policy-generator"
+	const secret = "grc-e2e-subscription-admin-user"
+	const subAdminBinding = "open-cluster-management:subscription-admin"
+	ocpUser := common.OCPUser{
+		ClusterRoles: []types.NamespacedName{
+			{Name: "open-cluster-management:admin:local-cluster"},
+			{
+				Name:      "admin",
+				Namespace: namespace,
+			},
+		},
+		// To be considered a subscription-admin you must be part of this cluster role binding.
+		// Having the proper role in another cluster role binding does not work.
+		ClusterRoleBindings: []string{subAdminBinding},
+		Password:            "",
+		Username:            "grc-e2e-subscription-admin",
+	}
+
+	It("Sets up the application subscription", func() {
+		By("Verifying that the subscription-admin ClusterRoleBinding exists")
+		// Occasionally, the subscription-admin ClusterRoleBinding may not exist due to some unknown
+		// error. This ClusterRoleBinding is supposed to have been created by the App Lifecycle
+		// controllers. In this unusual case, create the ClusterRoleBinding based on the advice from
+		// the Application Lifecycle squad.
+		subAdminBindingObj := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: subAdminBinding,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     subAdminBinding,
+			},
+		}
+		_, err := clientHub.RbacV1().ClusterRoleBindings().Create(
+			context.TODO(), &subAdminBindingObj, metav1.CreateOptions{},
+		)
+		if err != nil {
+			Expect(k8serrors.IsAlreadyExists(err)).Should(
+				BeTrue(),
+				"Expected error to be 'already exists': "+fmt.Sprint(err),
+			)
+		}
+
+		By("Cleaning up any existing subscription-admin user config")
+		cleanup(namespace, secret, ocpUser)
+
+		By("Creating a subscription-admin user and configuring IDP")
+		// Create a namespace to house the subscription configuration.
+		nsObj := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		_, err = clientHub.CoreV1().Namespaces().Create(
+			context.TODO(), &nsObj, metav1.CreateOptions{},
+		)
+		Expect(err).Should(BeNil())
+
+		// Create a subscription and local-cluster administrator OpenShift user that can be used
+		// for logging in.
+		userPassword, err := common.GenerateInsecurePassword()
+		Expect(err).Should(BeNil())
+		ocpUser.Password = userPassword
+		err = common.CreateOCPUser(clientHub, clientHubDynamic, secret, ocpUser)
+		Expect(err).Should(BeNil())
+
+		// Get a kubeconfig logged in as the subscription and local-cluster administrator OpenShift
+		// user.
+		hubServerURL, err := common.OcHub("whoami", "--show-server=true")
+		Expect(err).Should(BeNil())
+		hubServerURL = strings.TrimSuffix(hubServerURL, "\n")
+		// Use eventually since it can take a while for OpenShift to configure itself with the new
+		// identity provider (IDP).
+		var kubeconfigSubAdmin string
+		const fiveMinutes = 5 * 60
+		Eventually(
+			func() error {
+				var err error
+				kubeconfigSubAdmin, err = common.GetKubeConfig(
+					hubServerURL, ocpUser.Username, ocpUser.Password,
+				)
+
+				return err
+			},
+			fiveMinutes,
+			10,
+		).Should(BeNil())
+		// Delete the kubeconfig file after the test.
+		defer func() { os.Remove(kubeconfigSubAdmin) }()
+
+		By("Creating the application subscription")
+		_, err = common.OcHub(
+			"apply",
+			"-f",
+			"../resources/policy_generator/subscription-remote.yaml",
+			"-n",
+			namespace,
+			"--kubeconfig="+kubeconfigSubAdmin,
+		)
+		Expect(err).Should(BeNil())
+
+		// Perform some basic validation on the generated policy.
+		By("Checking that the root policy was created")
+		policyRsrc := clientHubDynamic.Resource(common.GvrPolicy)
+		var policy *unstructured.Unstructured
+		Eventually(
+			func() error {
+				var err error
+				policy, err = policyRsrc.Namespace(namespace).Get(
+					context.TODO(), policyName, metav1.GetOptions{},
+				)
+
+				return err
+			},
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(BeNil())
+
+		templates, found, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
+		Expect(err).Should(BeNil())
+		Expect(found).Should(BeTrue())
+		Expect(len(templates)).Should(Equal(3))
+
+		for _, template := range templates {
+			objSpec, found, err := unstructured.NestedMap(template.(map[string]interface{}), "objectDefinition", "spec")
+			Expect(err).Should(BeNil())
+			Expect(found).Should(BeTrue())
+			Expect(objSpec["severity"]).Should(Equal("high"))
+			objTemplates, found, err := unstructured.NestedSlice(objSpec, "object-templates")
+			Expect(err).Should(BeNil())
+			Expect(found).Should(BeTrue())
+			Expect(len(objTemplates)).Should(Equal(1))
+			templateObj := objTemplates[0].(map[string]interface{})
+			Expect(templateObj["complianceType"]).Should(Equal("mustnothave"))
+		}
+
+		By("Checking that the policy was propagated to the local-cluster namespace")
+		Eventually(
+			func() error {
+				var err error
+				policy, err = policyRsrc.Namespace("local-cluster").Get(
+					context.TODO(),
+					namespace+"."+policyName,
+					metav1.GetOptions{},
+				)
+
+				return err
+			},
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(BeNil())
+
+		By("Checking that the configuration policies were created in the local-cluster namespace")
+		configPolicyRsrc := clientHubDynamic.Resource(common.GvrConfigurationPolicy)
+		for _, suffix := range []string{"", "2", "3"} {
+			Eventually(
+				func() error {
+					var err error
+					policy, err = configPolicyRsrc.Namespace("local-cluster").Get(
+						context.TODO(), policyName+suffix, metav1.GetOptions{},
+					)
+
+					return err
+				},
+				defaultTimeoutSeconds,
+				1,
+			).Should(BeNil())
+		}
+	})
+
+	AfterAll(func() {
+		By("Cleaning up the changes made to the cluster in the test")
+		cleanup(namespace, secret, ocpUser)
+	})
+})

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -4,117 +4,34 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"in an App subscription", Ordered, Label("BVT"), func() {
+	const policyName = "e2e-grc-policy-app"
 	const namespace = "grc-e2e-policy-generator"
-	const secret = "grc-e2e-subscription-admin-user"
-	const subAdminBinding = "open-cluster-management:subscription-admin"
-	ocpUser := common.OCPUser{
-		ClusterRoles: []types.NamespacedName{
-			{Name: "open-cluster-management:admin:local-cluster"},
-			{
-				Name:      "admin",
-				Namespace: namespace,
-			},
-		},
-		ClusterRoleBindings: []string{subAdminBinding},
-		Password:            "",
-		Username:            "grc-e2e-subscription-admin",
-	}
+	const username = "grc-e2e-subadmin-user-polgen"
+	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
-		By("Verifying that the subscription-admin ClusterRoleBinding exists")
-		// Occasionally, the subscription-admin ClusterRoleBinding may not exist due to some unknown
-		// error. This ClusterRoleBinding is supposed to have been created by the App Lifecycle
-		// controllers. In this unusual case, create the ClusterRoleBinding based on the advice from
-		// the Application Lifecycle squad.
-		subAdminBindingObj := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: subAdminBinding,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     subAdminBinding,
-			},
-		}
-		_, err := clientHub.RbacV1().ClusterRoleBindings().Create(
-			context.TODO(), &subAdminBindingObj, metav1.CreateOptions{},
-		)
-		if err != nil {
-			Expect(k8serrors.IsAlreadyExists(err)).Should(
-				BeTrue(),
-				"Expected error to be 'already exists': "+fmt.Sprint(err),
-			)
-		}
-
-		By("Cleaning up any existing subscription-admin user config")
-		cleanup(namespace, secret, ocpUser)
-
-		By("Creating a subscription-admin user and configuring IDP")
-		// Create a namespace to house the subscription configuration.
-		nsObj := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		_, err = clientHub.CoreV1().Namespaces().Create(
-			context.TODO(), &nsObj, metav1.CreateOptions{},
-		)
-		Expect(err).Should(BeNil())
-
-		// Create a subscription and local-cluster administrator OpenShift user that can be used
-		// for logging in.
-		userPassword, err := common.GenerateInsecurePassword()
-		Expect(err).Should(BeNil())
-		ocpUser.Password = userPassword
-		err = common.CreateOCPUser(clientHub, clientHubDynamic, secret, ocpUser)
-		Expect(err).Should(BeNil())
-
-		// Get a kubeconfig logged in as the subscription and local-cluster administrator OpenShift
-		// user.
-		hubServerURL, err := common.OcHub("whoami", "--show-server=true")
-		Expect(err).Should(BeNil())
-		hubServerURL = strings.TrimSuffix(hubServerURL, "\n")
-		// Use eventually since it can take a while for OpenShift to configure itself with the new
-		// identity provider (IDP).
-		var kubeconfigSubAdmin string
-		const fiveMinutes = 5 * 60
-		Eventually(
-			func() error {
-				var err error
-				kubeconfigSubAdmin, err = common.GetKubeConfig(
-					hubServerURL, ocpUser.Username, ocpUser.Password,
-				)
-
-				return err
-			},
-			fiveMinutes,
-			10,
-		).Should(BeNil())
-		// Delete the kubeconfig file after the test.
-		defer func() { os.Remove(kubeconfigSubAdmin) }()
+		By("Creating and setting up the GitOps user")
+		ocpUser = common.GitOpsUserSetup(namespace, username)
 
 		By("Creating the application subscription")
-		_, err = common.OcHub(
+		_, err := common.OcUser(
+			ocpUser,
 			"apply",
 			"-f",
 			"../resources/policy_generator/subscription.yaml",
 			"-n",
 			namespace,
-			"--kubeconfig="+kubeconfigSubAdmin,
 		)
 		Expect(err).Should(BeNil())
 	})
@@ -143,7 +60,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 		Expect(err).Should(BeNil())
 		Expect(found).Should(BeTrue())
 		Expect(len(policies)).Should(Equal(1))
-		Expect(policies[0]).Should(Equal("e2e-grc-policy-app"))
+		Expect(policies[0]).Should(Equal(policyName))
 
 		By("Checking that the root policy was created")
 		policyRsrc := clientHubDynamic.Resource(common.GvrPolicy)
@@ -152,7 +69,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			func() error {
 				var err error
 				policy, err = policyRsrc.Namespace(namespace).Get(
-					context.TODO(), "e2e-grc-policy-app", metav1.GetOptions{},
+					context.TODO(), policyName, metav1.GetOptions{},
 				)
 
 				return err
@@ -182,7 +99,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 				var err error
 				policy, err = policyRsrc.Namespace("local-cluster").Get(
 					context.TODO(),
-					"grc-e2e-policy-generator.e2e-grc-policy-app",
+					namespace+"."+policyName,
 					metav1.GetOptions{},
 				)
 
@@ -198,7 +115,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			func() error {
 				var err error
 				policy, err = configPolicyRsrc.Namespace("local-cluster").Get(
-					context.TODO(), "e2e-grc-policy-app", metav1.GetOptions{},
+					context.TODO(), policyName, metav1.GetOptions{},
 				)
 
 				return err
@@ -210,6 +127,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 
 	AfterAll(func() {
 		By("Cleaning up the changes made to the cluster in the test")
-		cleanup(namespace, secret, ocpUser)
+		common.GitOpsCleanup(namespace, ocpUser)
 	})
 })

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -33,8 +33,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 				Namespace: namespace,
 			},
 		},
-		// To be considered a subscription-admin you must be part of this cluster role binding.
-		// Having the proper role in another cluster role binding does not work.
 		ClusterRoleBindings: []string{subAdminBinding},
 		Password:            "",
 		Username:            "grc-e2e-subscription-admin",
@@ -119,7 +117,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			"--kubeconfig="+kubeconfigSubAdmin,
 		)
 		Expect(err).Should(BeNil())
+	})
 
+	It("Validates the propagated policies", func() {
 		By("Checking that the policy set was created")
 		policySetRsrc := clientHubDynamic.Resource(common.GvrPolicySet)
 		var policyset *unstructured.Unstructured


### PR DESCRIPTION
This tests the functionality to provide a remote Kustomize directory to `manifests[].path`

Depends on:
- PolicyGenerator Kustomization (pointing to the `grc-e2e-policy-generator-test` repo): 
  - #496 
- Remote Kustomization: 
  - https://github.com/stolostron/grc-e2e-policy-generator-test/pull/3

ref: 
- https://github.com/stolostron/backlog/issues/25928
