### PR TITLE
Increase maximum test time

### DIFF
--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+while sleep 5m; do echo "\n=====[ $SECONDS seconds elapsed, keep Travis running ]=====\n"; done &
+
 printf "* Running E2E "
 if [ "$deployOnHub" == "true" ]; then
     echo "with deployOnHub=true..."

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -37,7 +37,7 @@ var (
 	ClientManagedDynamic dynamic.Interface
 )
 
-const MaxTravisTimeoutSeconds = 590 // Travis times out (by default) at 10 minutes
+const MaxTimeoutSeconds = 900 // 15 minutes
 
 func InitFlags(flagset *flag.FlagSet) {
 	if flagset == nil {

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -127,7 +127,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 				)
 
 				return compliancesuite.Object["status"].(map[string]interface{})["phase"]
-			}, common.MaxTravisTimeoutSeconds, 1).Should(Equal("RUNNING"))
+			}, common.MaxTimeoutSeconds, 1).Should(Equal("RUNNING"))
 		})
 		It("Informing stable/"+scanPolicyName+"", func() {
 			Eventually(func() interface{} {
@@ -190,7 +190,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 				g.Expect(err).To(BeNil())
 
 				return len(list.Items)
-			}, common.MaxTravisTimeoutSeconds, 1).ShouldNot(Equal(0))
+			}, common.MaxTimeoutSeconds, 1).ShouldNot(Equal(0))
 		})
 		It("ComplianceSuite "+scanName+" scan results should be AGGREGATING", func() {
 			By("Checking if ComplianceSuite " + scanName + " scan status.phase is AGGREGATING")
@@ -205,7 +205,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 				)
 
 				return compliancesuite.Object["status"].(map[string]interface{})["phase"]
-			}, common.MaxTravisTimeoutSeconds, 1).Should(Equal("AGGREGATING"))
+			}, common.MaxTimeoutSeconds, 1).Should(Equal("AGGREGATING"))
 		})
 		It("ComplianceSuite "+scanName+" scan results should be DONE", func() {
 			By("Checking if ComplianceSuite " + scanName + " scan status.phase is DONE")
@@ -220,7 +220,7 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 				)
 
 				return compliancesuite.Object["status"].(map[string]interface{})["phase"]
-			}, common.MaxTravisTimeoutSeconds, 1).Should(Equal("DONE"))
+			}, common.MaxTimeoutSeconds, 1).Should(Equal("DONE"))
 		})
 	})
 	AfterAll(func() {

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -175,7 +175,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 
 				return ""
 			},
-			common.MaxTravisTimeoutSeconds,
+			common.MaxTimeoutSeconds,
 			1,
 		).Should(Equal(string(policiesv1.NonCompliant)))
 	})

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -106,7 +106,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 
 				return int64(0)
 			},
-			common.MaxTravisTimeoutSeconds,
+			common.MaxTimeoutSeconds,
 			1,
 		).Should(BeNumerically("==", int64(1)))
 	})


### PR DESCRIPTION
Previously, we were somewhat limited because the tests run in Travis, whichmight assume things are broken and abort the tests if nothing is written to stdout in a while. Now, a one-liner will prevent that, so we can increase the maximum timeout.

Refs:
 - https://github.com/stolostron/backlog/issues/26165

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>