### PR TITLE
Add CRD sync checking to the periodic CI script

### DIFF
--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /bin/bash
 
 # Validate the pipeline is up to date and that no failed prow jobs exist
 
@@ -47,11 +47,9 @@ getSyncIssues() {
 getGitSha() {
 	component=$1
 	release=release-$2
-	cd $COMPONENT_ORG/$component
-	co=`git checkout --quiet $release`
-	GITSHA=`git log -n 1 --no-decorate --pretty=oneline | awk '{print $1}'`
+	co=`git -C $COMPONENT_ORG/$component checkout --quiet $release`
+	GITSHA=`git -C $COMPONENT_ORG/$component log -n 1 --no-decorate --pretty=oneline | awk '{print $1}'`
 	echo "$GITSHA"
-	cd $BASEDIR
 }
 
 # Fetch a value from the Pipeline manifest
@@ -61,11 +59,9 @@ getPipelineValue() {
 	release="${2}-integration"
 	key="$3"
 
-	cd pipeline
-	co=$(git checkout --quiet "$release")
-	value=`jq -r '.[] |select(.["image-name"] == "'$component'") | .["'$key'"]' manifest.json`
+	co=$(git -C pipeline/ checkout --quiet "$release")
+	value=`jq -r '.[] |select(.["image-name"] == "'$component'") | .["'$key'"]' pipeline/manifest.json`
 	echo "$value"
-	cd $BASEDIR
 }
 
 # Check for Prow job failures
@@ -122,10 +118,9 @@ cleanup() {
 	rm -rf "$COMPONENT_ORG"
 }
 
-BASEDIR=$(pwd)
 rc=0
 
-ARTIFACT_DIR=${ARTIFACT_DIR:-${BASEDIR}}
+ARTIFACT_DIR=${ARTIFACT_DIR:-$(pwd)}
 ERROR_FILE="${ARTIFACT_DIR}/errors.log"
 
 # Clean up error file if it exists

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -4,7 +4,7 @@
 
 COMPONENT_ORG=stolostron
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-"main"}
-CHECK_RELEASES="2.3 2.4 2.5 2.6 2.7"
+CHECK_RELEASES="2.4 2.5 2.6 2.7"
 # This list can include all postsubmit jobs for all repos--if a job doesn't exist it's filtered to empty and skipped
 CHECK_JOBS=${CHECK_JOBS:-"publish publish-test images latest-image-mirror latest-test-image-mirror"}
 

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -22,7 +22,12 @@ cloneRepos() {
 		# Collect repos from https://github.com/stolostron/policy-grc-squad/blob/master/main-branch-sync/repo.txt
 		REPOS=$(cat policy-grc-squad/main-branch-sync/repo.txt)
 		# Manually append deprecated repos
-		REPOS="${REPOS} stolostron/grc-ui stolostron/grc-ui-api"
+		REPOS="${REPOS}
+			stolostron/grc-ui
+			stolostron/grc-ui-api
+			stolostron/governance-policy-spec-sync
+			stolostron/governance-policy-status-sync
+			stolostron/governance-policy-template-sync"
 		for repo in $REPOS; do
 			echo "Cloning $repo ...."
 			git clone --quiet https://github.com/$repo.git $repo

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -7,17 +7,16 @@ DEFAULT_BRANCH=${DEFAULT_BRANCH:-"main"}
 CHECK_RELEASES="2.4 2.5 2.6 2.7"
 # This list can include all postsubmit jobs for all repos--if a job doesn't exist it's filtered to empty and skipped
 CHECK_JOBS=${CHECK_JOBS:-"publish publish-test images latest-image-mirror latest-test-image-mirror"}
+UTIL_REPOS="policy-grc-squad pipeline multiclusterhub-operator"
 
 # Clone the repositories needed for this script to work
 cloneRepos() {
-	if [ ! -d "policy-grc-squad" ]; then
-		echo "Cloning policy-grc-squad ..."
-		git clone --quiet https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/$COMPONENT_ORG/policy-grc-squad.git
-	fi
-	if [ ! -d "pipeline" ]; then
-		echo "Cloning pipeline ..."
-		git clone --quiet https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/$COMPONENT_ORG/pipeline.git
-	fi
+	for prereqrepo in ${UTIL_REPOS}; do
+		if [ ! -d ${prereqrepo} ]; then
+			echo "Cloning ${prereqrepo} ..."
+			git clone --quiet https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${COMPONENT_ORG}/${prereqrepo}.git
+		fi
+	done
 	if [ ! -d "${COMPONENT_ORG}" ]; then
 		# Collect repos from https://github.com/stolostron/policy-grc-squad/blob/master/main-branch-sync/repo.txt
 		REPOS=$(cat policy-grc-squad/main-branch-sync/repo.txt)
@@ -117,9 +116,9 @@ checkProwJob() {
 }
 
 cleanup() {
-	cd "$BASEDIR"
-	rm -rf pipeline
-	rm -rf policy-grc-squad
+	for repo_dir in ${UTIL_REPOS}; do
+		rm -rf ${repo_dir}
+	done
 	rm -rf "$COMPONENT_ORG"
 }
 


### PR DESCRIPTION
We have CRDs synced to `multiclusterhub-operator` and an action running already that checks the `governance-policy-addon-controller`. This adds a check to make sure both of those are up-to-date/passing.

Note that this check will currently be failing until this PR is merged:
- https://github.com/stolostron/multiclusterhub-operator/pull/885