### PR TITLE
Remove `-user` suffix from IDP name in cleanup

### DIFF
--- a/test/common/user_management.go
+++ b/test/common/user_management.go
@@ -451,6 +451,28 @@ func CleanupOCPUser(
 // deleteHtPasswd deletes the htpasswd identity provider configuration entry of the input name and
 // deletes the User and Identity objects created by OpenShift.
 func deleteHtPasswd(dynamicClient dynamic.Interface, authName string, user OCPUser) error {
+	// Delete the User and Identity objects created by OpenShift
+	err := dynamicClient.Resource(GvrUser).Delete(
+		context.TODO(), user.Username, metav1.DeleteOptions{},
+	)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf(
+			`failed to delete the OpenShift "User" of "%s": %w`, user.Username, err,
+		)
+	}
+
+	identityName := fmt.Sprintf("%s:%s", user.Username, user.Username)
+
+	err = dynamicClient.Resource(GvrIdentity).Delete(
+		context.TODO(), identityName, metav1.DeleteOptions{},
+	)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf(
+			`failed to delete the OpenShift "Identity" of "%s": %w`, identityName, err,
+		)
+	}
+
+	// Remove the Identity Provider (IDP) from the OAuth object
 	const oAuthName = "cluster"
 
 	clusterOAuth, err := getClusterOAuthConfig(dynamicClient)
@@ -521,27 +543,6 @@ func deleteHtPasswd(dynamicClient dynamic.Interface, authName string, user OCPUs
 			oAuthName,
 			idpIndex,
 			err,
-		)
-	}
-
-	// Delete the User and Identity objects created by OpenShift
-	err = dynamicClient.Resource(GvrUser).Delete(
-		context.TODO(), user.Username, metav1.DeleteOptions{},
-	)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return fmt.Errorf(
-			`failed to delete the OpenShift "User" of "%s": %w`, user.Username, err,
-		)
-	}
-
-	identityName := fmt.Sprintf("%s-user:%s", user.Username, user.Username)
-
-	err = dynamicClient.Resource(GvrIdentity).Delete(
-		context.TODO(), identityName, metav1.DeleteOptions{},
-	)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return fmt.Errorf(
-			`failed to delete the OpenShift "Identity" of "%s": %w`, identityName, err,
 		)
 	}
 


### PR DESCRIPTION
A `-user` suffix that was removed in the refactor had inadvertently been left behind when deleting the Identity objects.
This PR also shuffles commands to delete user-specific objects first and adds additional headings to make cleanup steps more visible.

I'm not 100% sure it'll help, but hopefully it will. I've cleaned up leftover Identities, so if the next run passes it's probable that this PR will address the failures:
```
$ oc delete identity --all
identity.user.openshift.io "grc-e2e-hardening-sub-admin-user:grc-e2e-subscription-admin" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-hardening:grc-e2e-subadmin-user-hardening" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-hardening:grc-e2e-subadmin-user-polgen" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-hardening:grc-e2e-subadmin-user-remotepolgen" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-polgen:grc-e2e-subadmin-user-hardening" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-polgen:grc-e2e-subadmin-user-polgen" deleted
identity.user.openshift.io "grc-e2e-subadmin-user-remotepolgen:grc-e2e-subadmin-user-remotepolgen" deleted
identity.user.openshift.io "grc-e2e-subscription-admin-user:grc-e2e-hardening-sub-admin" deleted
```