### PR TITLE
Delete the Kyverno webhooks before the deployment 

### DIFF
--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -292,6 +292,28 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 		)
 		Expect(err).To(BeNil())
 
+		// make sure kyverno mutating webhooks are removed
+		_, err = utils.KubectlWithOutput(
+			"delete", "mutatingwebhookconfigurations",
+			"kyverno-policy-mutating-webhook-cfg",
+			"kyverno-resource-mutating-webhook-cfg",
+			"kyverno-verify-mutating-webhook-cfg",
+			"--kubeconfig="+kubeconfigManaged,
+			"--ignore-not-found",
+		)
+		Expect(err).To(BeNil())
+
+		// make sure kyverno validating webhooks are removed
+		_, err = utils.KubectlWithOutput(
+			"delete",
+			"validatingwebhookconfigurations",
+			"kyverno-policy-validating-webhook-cfg",
+			"kyverno-resource-validating-webhook-cfg",
+			"--kubeconfig="+kubeconfigManaged,
+			"--ignore-not-found",
+		)
+		Expect(err).To(BeNil())
+
 		// delete the namespace created to test the generators
 		_, err = utils.KubectlWithOutput(
 			"delete", "ns", testNamespace,
@@ -313,28 +335,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 		_, err = utils.KubectlWithOutput(
 			"delete", "ns",
 			"kyverno",
-			"--kubeconfig="+kubeconfigManaged,
-			"--ignore-not-found",
-		)
-		Expect(err).To(BeNil())
-
-		// make sure kyverno mutating webhooks are removed
-		_, err = utils.KubectlWithOutput(
-			"delete", "mutatingwebhookconfigurations",
-			"kyverno-policy-mutating-webhook-cfg",
-			"kyverno-resource-mutating-webhook-cfg",
-			"kyverno-verify-mutating-webhook-cfg",
-			"--kubeconfig="+kubeconfigManaged,
-			"--ignore-not-found",
-		)
-		Expect(err).To(BeNil())
-
-		// make sure kyverno validating webhooks are removed
-		_, err = utils.KubectlWithOutput(
-			"delete",
-			"validatingwebhookconfigurations",
-			"kyverno-policy-validating-webhook-cfg",
-			"kyverno-resource-validating-webhook-cfg",
 			"--kubeconfig="+kubeconfigManaged,
 			"--ignore-not-found",
 		)

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -333,7 +333,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 		_, err = utils.KubectlWithOutput(
 			"delete",
 			"validatingwebhookconfigurations",
-			"kyverno-policy-validating-webhook-cf",
+			"kyverno-policy-validating-webhook-cfg",
 			"kyverno-resource-validating-webhook-cfg",
 			"--kubeconfig="+kubeconfigManaged,
 			"--ignore-not-found",


### PR DESCRIPTION
This avoids a race condition where the webhooks are still present but Kyverno is down and blocks API actions. This also fixes a typo in one of the Kyverno webhook deletion commands.