### PR TITLE
Add missing assertions on Eventually calls

### DIFF
--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -251,6 +251,6 @@ func EnforcePolicy(policyName string, templateGVRs ...schema.GroupVersionResourc
 			g.ExpectWithOffset(1, err).To(BeNil())
 			g.ExpectWithOffset(1, found).To(BeTrue())
 			g.ExpectWithOffset(1, action).To(Equal("enforce"))
-		}, DefaultTimeoutSeconds, 1)
+		}, DefaultTimeoutSeconds, 1).Should(Succeed())
 	}
 }

--- a/test/configuration_policy_prune.go
+++ b/test/configuration_policy_prune.go
@@ -220,7 +220,7 @@ func ConfigPruneBehavior(labels ...string) bool {
 			initialValue, ok = data["testvalue"].(string)
 			g.Expect(ok).To(BeTrue())
 			g.Expect(len(initialValue)).To(BeNumerically(">", 0))
-		}, DefaultTimeoutSeconds, 1)
+		}, DefaultTimeoutSeconds, 1).Should(Succeed())
 
 		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
@@ -243,7 +243,7 @@ func ConfigPruneBehavior(labels ...string) bool {
 			newValue, ok := data["testvalue"].(string)
 			g.Expect(ok).To(BeTrue())
 			g.Expect(newValue).To(Not(Equal(initialValue)))
-		}, DefaultTimeoutSeconds, 1)
+		}, DefaultTimeoutSeconds, 1).Should(Succeed())
 
 		DoCleanupPolicy(policyYaml, GvrConfigurationPolicy)
 

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -352,6 +352,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 				"--kubeconfig="+kubeconfigManaged, "--ignore-not-found",
 			)
 			g.Expect(err).To(BeNil())
-		}, defaultTimeoutSeconds*2)
+		}, defaultTimeoutSeconds*2).Should(Succeed())
 	})
 })

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -122,7 +122,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			output, err = utils.KubectlWithOutput("apply",
 				"-f", testUndoPolicySetPatchYaml,
 				"-n", userNamespace,
-				"--kubeconfig=../../kubeconfig_hub")
+				"--kubeconfig="+kubeconfigHub)
 			By("Creating " + testUndoPolicySetPatchYaml + " result is " + output)
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
Gomega seems to ignore the Eventually calls if there is no assertion on them.