### PR TITLE
Set timeouts when deleting the Kyverno namespaces

### DIFF
--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -293,26 +293,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 			)
 			g.Expect(err).To(BeNil())
 
-			// delete the channel namespace
-			_, err = utils.KubectlWithOutput(
-				"delete", "ns",
-				"kyverno-channel",
-				"--kubeconfig="+kubeconfigManaged,
-				"--ignore-not-found",
-			)
-			g.Expect(err).To(BeNil())
-
-			// make sure kyverno mutating webhooks are removed
-			_, err = utils.KubectlWithOutput(
-				"delete", "mutatingwebhookconfigurations",
-				"kyverno-policy-mutating-webhook-cfg",
-				"kyverno-resource-mutating-webhook-cfg",
-				"kyverno-verify-mutating-webhook-cfg",
-				"--kubeconfig="+kubeconfigManaged,
-				"--ignore-not-found",
-			)
-			g.Expect(err).To(BeNil())
-
 			// make sure kyverno validating webhooks are removed
 			_, err = utils.KubectlWithOutput(
 				"delete",
@@ -324,11 +304,22 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 			)
 			g.Expect(err).To(BeNil())
 
+			// delete the channel namespace
+			_, err = utils.KubectlWithOutput(
+				"delete", "ns",
+				"kyverno-channel",
+				"--kubeconfig="+kubeconfigManaged,
+				"--ignore-not-found",
+				"--timeout=10s",
+			)
+			g.Expect(err).To(BeNil())
+
 			// delete the namespace created to test the generators
 			_, err = utils.KubectlWithOutput(
 				"delete", "ns", testNamespace,
 				"--kubeconfig="+kubeconfigManaged,
 				"--ignore-not-found",
+				"--timeout=10s",
 			)
 			g.Expect(err).To(BeNil())
 
@@ -338,6 +329,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 				kyvernoNamespace,
 				"--kubeconfig="+kubeconfigManaged,
 				"--ignore-not-found",
+				"--timeout=10s",
 			)
 			g.Expect(err).To(BeNil())
 


### PR DESCRIPTION
This shifts deleting the webhooks up in the Eventually so it is deleted again in the event of a race condition.