### PR TITLE
Increase the timeout when deleting the GitOps test namespace

### DIFF
--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -152,7 +152,7 @@ func GitOpsCleanup(namespace string, user OCPUser) {
 
 			return isNotFound
 		},
-		DefaultTimeoutSeconds,
+		DefaultTimeoutSeconds*2,
 		1,
 	).Should(BeTrue())
 }


### PR DESCRIPTION
I've seen this happen a few times and figure it can't hurt to increase the timeout.