### PR TITLE
Delete the Kyverno subscription on the Hub

### DIFF
--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -122,4 +122,9 @@ var (
 		Version:  "v1",
 		Resource: "identities",
 	}
+	GvrManagedClusterSet = schema.GroupVersionResource{
+		Group:    "cluster.open-cluster-management.io",
+		Version:  "v1beta2",
+		Resource: "managedclustersets",
+	}
 )

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -63,6 +63,24 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			Expect(k8serrors.IsAlreadyExists(err)).Should(BeTrue())
 		}
 
+		By("Verifying that the default ManagedClusterSet exists")
+		mcs := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1beta2",
+				"kind":       "ManagedClusterSet",
+				"metadata": map[string]interface{}{
+					"name": "default",
+				},
+			},
+		}
+
+		_, err = clientHubDynamic.Resource(common.GvrManagedClusterSet).Create(
+			context.TODO(), &mcs, metav1.CreateOptions{},
+		)
+		if !k8serrors.IsAlreadyExists(err) {
+			Expect(err).To(BeNil())
+		}
+
 		By("Creating the application subscription")
 		_, err = common.OcUser(
 			ocpUser,

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -293,6 +293,17 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 			)
 			g.Expect(err).To(BeNil())
 
+			// make sure kyverno mutating webhooks are removed
+			_, err = utils.KubectlWithOutput(
+				"delete", "mutatingwebhookconfigurations",
+				"kyverno-policy-mutating-webhook-cfg",
+				"kyverno-resource-mutating-webhook-cfg",
+				"kyverno-verify-mutating-webhook-cfg",
+				"--kubeconfig="+kubeconfigManaged,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+
 			// make sure kyverno validating webhooks are removed
 			_, err = utils.KubectlWithOutput(
 				"delete",

--- a/test/integration/policy_kyverno_generators_test.go
+++ b/test/integration/policy_kyverno_generators_test.go
@@ -288,7 +288,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the kyverno generator "+
 			_, err = utils.KubectlWithOutput(
 				"delete", "subscription.apps.open-cluster-management.io",
 				"-n", kyvernoNamespace, "--all",
-				"--kubeconfig="+kubeconfigManaged,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			g.Expect(err).To(BeNil())


### PR DESCRIPTION
This is also adds back deleting the mutation webhooks which was removed by accident in a previous commit.

Relates:
https://github.com/stolostron/backlog/issues/26834