### PR TITLE
Clean up any stale identities

### DIFF
--- a/build/patch-dev-images.sh
+++ b/build/patch-dev-images.sh
@@ -42,7 +42,7 @@ for MANAGED_CLUSTER in ${MANAGED_CLUSTERS}; do
       echo "* Wait for manifestwork on ${MANAGED_CLUSTER}:"
       FOUND="true"
       for COMPONENT in ${ADDON_COMPONENTS[@]}; do
-        if (! oc get manifestwork -n ${MANAGED_CLUSTER} addon-${COMPONENT}-deploy); then
+        if (! oc get manifestwork -n ${MANAGED_CLUSTER} addon-${COMPONENT}-deploy-0); then
           FOUND="false"
         fi
       done

--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -18,11 +18,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const gitOpsUserPrefix = "grc-e2e-subadmin-user-"
+
 // GitOpsUserSetup configures a new user to use for the GitOps deployments.
 // The provided namespace is deleted and recreated as part of the setup.
 // It returns the OCPUser instance, which contains a path to the created kubeconfig file.
 func GitOpsUserSetup(
-	namespace string, username string, additionalRoles ...types.NamespacedName,
+	namespace string, usernameSuffix string, additionalRoles ...types.NamespacedName,
 ) OCPUser {
 	const subAdminBinding = "open-cluster-management:subscription-admin"
 
@@ -36,7 +38,7 @@ func GitOpsUserSetup(
 		},
 		ClusterRoleBindings: []string{subAdminBinding},
 		Password:            "",
-		Username:            username,
+		Username:            gitOpsUserPrefix + usernameSuffix,
 	}
 
 	// Append any additional provided ClusterRoles

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -26,14 +26,14 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 		"policy-subscriptions",
 	}
 	const namespace = "policies"
-	const username = "grc-e2e-subadmin-user-hardening"
+	const usernameSuffix = "hardening"
 	const clustersetRoleName = "grc-e2e-clusterset-role"
 	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
 		By("Creating and setting up the GitOps user")
 		ocpUser = common.GitOpsUserSetup(
-			namespace, username, types.NamespacedName{Name: clustersetRoleName},
+			namespace, usernameSuffix, types.NamespacedName{Name: clustersetRoleName},
 		)
 
 		By("Setting up the managed cluster set binding role for the GitOps user")

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -17,12 +17,12 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"with a remote Kustomize directory", Ordered, Label("SVT"), func() {
 	const policyName = "e2e-grc-remote-policy-app"
 	const namespace = "grc-e2e-remote-policy-generator"
-	const username = "grc-e2e-subadmin-user-remotepolgen"
+	const usernameSuffix = "remotepolgen"
 	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
 		By("Creating and setting up the GitOps user")
-		ocpUser = common.GitOpsUserSetup(namespace, username)
+		ocpUser = common.GitOpsUserSetup(namespace, usernameSuffix)
 
 		By("Creating the application subscription")
 		_, err := common.OcUser(

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -17,12 +17,12 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"in an App subscription", Ordered, Label("BVT"), func() {
 	const policyName = "e2e-grc-policy-app"
 	const namespace = "grc-e2e-policy-generator"
-	const username = "grc-e2e-subadmin-user-polgen"
+	const usernameSuffix = "polgen"
 	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
 		By("Creating and setting up the GitOps user")
-		ocpUser = common.GitOpsUserSetup(namespace, username)
+		ocpUser = common.GitOpsUserSetup(namespace, usernameSuffix)
 
 		By("Creating the application subscription")
 		_, err := common.OcUser(


### PR DESCRIPTION
The expectation is that identities would have the pattern `<username>:<username>` because we expect the username to match the IDP. But in case there was a stale IDP, and it's somehow used we want to make sure to clean it up also.