### PR TITLE
Test that the required default metrics are present

### DIFF
--- a/test/integration/verify_metrics_test.go
+++ b/test/integration/verify_metrics_test.go
@@ -1,0 +1,152 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/governance-policy-framework/test/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+)
+
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test required metrics are available", Ordered, Label("BVT"), func() {
+	const (
+		metricsAccName         = "grc-e2e-metrics-test"
+		metricsTokenName       = "grc-e2e-metrics-test-token-manual"
+		metricsTokenYAML       = "../resources/verify_metrics/metrics_token.yaml"
+		monitoringNS           = "openshift-monitoring"
+		noncompliantPolicyName = "policy-verify-metrics-noncompliant"
+		noncompliantPolicyYAML = "../resources/verify_metrics/noncompliant.yaml"
+		prometheusRouteName    = "prometheus-k8s"
+		roleBindingName        = "grc-e2e-metrics-test"
+	)
+	// Note that the spec-sync metrics are skipped due to it not being available on a self-managed Hub. The presence
+	// of the other sync metrics indicate that the metrics are exported from governance-policy-framework addon properly.
+	// Other metrics that require error conditions to show up are also skipped.
+	requiredMetrics := []string{
+		"config_policies_evaluation_duration_seconds_bucket",
+		"config_policies_evaluation_duration_seconds_count",
+		"config_policy_evaluation_seconds_total",
+		"config_policy_evaluation_total",
+		`controller_runtime_reconcile_errors_total{controller="policy-encryption-keys"}`,
+		`controller_runtime_reconcile_errors_total{controller="policy-set"}`,
+		`controller_runtime_reconcile_errors_total{controller="policy-propagator"}`,
+		`controller_runtime_reconcile_errors_total{controller="policy-status-sync"}`,
+		`controller_runtime_reconcile_time_seconds_bucket{controller="policy-propagator"}`,
+		`controller_runtime_reconcile_total{controller="policy-propagator"}`,
+		"ocm_handle_root_policy_duration_seconds_bucket_bucket",
+		`workqueue_depth{name="policy-status-sync"}`,
+		`workqueue_depth{name="policy-template-sync"}`,
+	}
+
+	AfterEach(func() {
+		_, err := common.OcHub("delete", "-f", noncompliantPolicyYAML, "-n", userNamespace, "--ignore-not-found")
+		Expect(err).To(BeNil())
+		_, err = common.OcHub("delete", "secret", metricsTokenName, "-n", userNamespace, "--ignore-not-found")
+		Expect(err).To(BeNil())
+		_, err = common.OcHub("delete", "clusterrolebinding", roleBindingName, "--ignore-not-found")
+		Expect(err).To(BeNil())
+		_, err = common.OcHub("delete", "serviceaccount", metricsAccName, "-n", userNamespace, "--ignore-not-found")
+		Expect(err).To(BeNil())
+	})
+
+	It("Verifies all required metrics are available", func() {
+		By("Creating a noncompliant policy")
+		_, err := common.OcHub("apply", "-f", noncompliantPolicyYAML, "-n", userNamespace)
+		Expect(err).To(BeNil())
+		Eventually(
+			common.GetComplianceState(noncompliantPolicyName),
+			defaultTimeoutSeconds*2,
+			1,
+		).Should(Equal(policiesv1.NonCompliant))
+
+		By("Finding the Prometheus route")
+		route, err := clientHubDynamic.Resource(common.GvrRoute).Namespace(monitoringNS).Get(
+			context.TODO(), prometheusRouteName, metav1.GetOptions{},
+		)
+		Expect(err).To(BeNil())
+
+		prometheusHost, _, _ := unstructured.NestedString(route.Object, "spec", "host")
+		Expect(prometheusHost).ToNot(HaveLen(0))
+
+		prometheusURL := "https://" + prometheusHost + "/api/v1/query"
+
+		By("Getting a token for a new service account")
+		_, err = common.OcHub("create", "serviceaccount", metricsAccName, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		_, err = common.OcHub(
+			"create",
+			"clusterrolebinding",
+			roleBindingName,
+			"--clusterrole=cluster-admin",
+			"--serviceaccount="+userNamespace+":"+metricsAccName,
+		)
+		Expect(err).To(BeNil())
+
+		_, err = common.OcHub("apply", "-f", metricsTokenYAML, "-n", userNamespace)
+		Expect(err).To(BeNil())
+
+		var encodedtoken string
+
+		// The secret could take a moment to be populated with the token
+		Eventually(func(g Gomega) {
+			var err error
+			encodedtoken, err = common.OcHub(
+				"get", "secret", metricsTokenName, "-n", userNamespace, "-o", "jsonpath={.data.token}",
+			)
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(encodedtoken).ToNot(HaveLen(0))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		decodedToken, err := base64.StdEncoding.DecodeString(encodedtoken)
+		Expect(err).To(BeNil())
+
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		httpClient := http.Client{Timeout: 15 * time.Second, Transport: transport}
+
+		for _, metric := range requiredMetrics {
+			By("Checking the metric " + metric)
+			req, err := http.NewRequest(http.MethodGet, prometheusURL, nil)
+			Expect(err).To(BeNil())
+
+			req.Header.Set("Authorization", "Bearer "+string(decodedToken))
+			req.Header.Set("Accept", "application/json")
+
+			q := req.URL.Query()
+			q.Add("query", metric)
+			req.URL.RawQuery = q.Encode()
+
+			res, err := httpClient.Do(req)
+			Expect(err).To(BeNil())
+
+			resBody, err := io.ReadAll(res.Body)
+			Expect(err).To(BeNil())
+
+			resJSON := map[string]interface{}{}
+			err = json.Unmarshal(resBody, &resJSON)
+			Expect(err).To(BeNil())
+			Expect(resJSON["status"]).To(Equal("success"))
+
+			data, ok := resJSON["data"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+
+			result, ok := data["result"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(result).ToNot(HaveLen(0))
+		}
+	})
+})

--- a/test/resources/verify_metrics/metrics_token.yaml
+++ b/test/resources/verify_metrics/metrics_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grc-e2e-metrics-test-token-manual
+  annotations:
+    kubernetes.io/service-account.name: grc-e2e-metrics-test
+type: kubernetes.io/service-account-token

--- a/test/resources/verify_metrics/noncompliant.yaml
+++ b/test/resources/verify_metrics/noncompliant.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-verify-metrics-noncompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-verify-metrics-noncompliant
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: policy-metric-test-noncompliant
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-verify-metrics-noncompliant
+placementRef:
+  name: placement-policy-verify-metrics-noncompliant
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-verify-metrics-noncompliant
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-verify-metrics-noncompliant
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions: []


### PR DESCRIPTION
Note that the spec-sync metrics are skipped due to it not being available on a self-managed Hub. The presence of the other sync metrics indicate that the metrics are exported from governance-policy-framework addon properly. Other metrics that require error conditions to show up are also skipped.

Relates:
https://issues.redhat.com/browse/ACM-2452