### PR TITLE
Add test for configpolicy cleanup during uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ e2e-debug-kind: e2e-debug
 	-@for APP in $(KIND_COMPONENTS); do\
 		for CONTAINER in $$(kubectl get pod -l $(KIND_COMPONENT_SELECTOR)=$${APP} -n $(KIND_MANAGED_NAMESPACE) -o jsonpath={.items[*].spec.containers[*].name}  --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)); do\
 			echo "* Logs for Label: $(KIND_COMPONENT_SELECTOR)=$${APP}, Container: $${CONTAINER}" > $(DEBUG_DIR)/managed_logs_$${CONTAINER}.log;\
-			kubectl logs -l $(KIND_COMPONENT_SELECTOR)=$${APP} -n $(KIND_MANAGED_NAMESPACE) -c $${CONTAINER} --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) >> $(DEBUG_DIR)/managed_logs_$${CONTAINER}.log;\
+			kubectl logs -l $(KIND_COMPONENT_SELECTOR)=$${APP} -n $(KIND_MANAGED_NAMESPACE) -c $${CONTAINER} --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME) --tail=-1 >> $(DEBUG_DIR)/managed_logs_$${CONTAINER}.log;\
 		done;\
 	done
 

--- a/test/configuration_policy_prune.go
+++ b/test/configuration_policy_prune.go
@@ -23,20 +23,18 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 	cleanPolicy := func(policyName, policyYaml string) func() {
 		return func() {
-			_, err := OcHub(
-				"delete", "-f", policyYaml,
-				"--ignore-not-found",
-			)
+			By("Cleaning up policy " + policyName + ", ignoring if not found")
+
+			outHub, err := OcHub("delete", "-f", policyYaml, "-n", UserNamespace, "--ignore-not-found")
+			GinkgoWriter.Printf("cleanPolicy OcHub output: %v\n", outHub)
 			Expect(err).To(BeNil())
-			_, err = OcManaged(
-				"delete",
-				"events",
-				"-n",
-				ClusterNamespace,
-				"--field-selector=involvedObject.name="+
-					UserNamespace+"."+policyName,
+
+			outManaged, err := OcManaged(
+				"delete", "events", "-n", ClusterNamespace,
+				"--field-selector=involvedObject.name="+UserNamespace+"."+policyName,
 				"--ignore-not-found",
 			)
+			GinkgoWriter.Printf("cleanPolicy OcManaged output: %v\n", outManaged)
 			Expect(err).To(BeNil())
 		}
 	}


### PR DESCRIPTION
Tests that the ConfigurationPolicy CRD does not become stuck due to pruneObjectBehavior finalizers when the controller is uninstalled.

Refs:
 - https://issues.redhat.com/browse/ACM-2923

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>