### PR TITLE
Install the oc client in the TravisCI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ stages:
 - test-etcd-encryption
 - ff
 # - hibernate
+before_script:
+- ${TRAVIS_BUILD_DIR}/build/download-clis.sh
 after_failure:
 - |
   [[ "$TRAVIS_BUILD_STAGE_NAME" == "test-"* ]] && make e2e-debug-dump


### PR DESCRIPTION
This was overlooked when the build harness was removed.

Signed-off-by: mprahl <mprahl@users.noreply.github.com>