### PR TITLE
add lastest msg check

### DIFF
--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -4,7 +4,7 @@
 
 COMPONENT_ORG=stolostron
 DEFAULT_BRANCH=${DEFAULT_BRANCH:-"main"}
-CHECK_RELEASES="2.4 2.5 2.6 2.7"
+CHECK_RELEASES="2.4 2.5 2.6 2.7 2.8"
 # This list can include all postsubmit jobs for all repos--if a job doesn't exist it's filtered to empty and skipped
 CHECK_JOBS=${CHECK_JOBS:-"publish publish-test images latest-image-mirror latest-test-image-mirror"}
 UTIL_REPOS="policy-grc-squad pipeline multiclusterhub-operator"

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -87,9 +87,34 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
+
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in namespace default missing",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default found "+
+					"as specified, therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in namespace "+
+					"default found but not as specified",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default found as specified, "+
+					"therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in namespace default missing",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default found as specified, "+
+					"therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in "+
+					"namespace default missing",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)
@@ -180,10 +205,37 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
-
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default was updated successfully",
+				"NonCompliant; violation - No instances of `roles` found as specified in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"was missing, and was created successfully",
+				"NonCompliant; violation - No instances of `roles` found as specified "+
+					"in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"was missing, and was created successfully",
+				"NonCompliant; violation - No instances of `roles` found as specified "+
+					"in namespaces: default",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in "+
+					"namespace default missing",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)
@@ -218,9 +270,26 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			Expect(err).To(BeNil())
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"Compliant; notification - roles [role-policy-e2e] in namespace default missing "+
+					"as expected, therefore this Object template is compliant",
+				"NonCompliant; violation - roles found: [role-policy-e2e] in namespace default",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default missing "+
+					"as expected, therefore this Object template is compliant",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)
@@ -271,9 +340,28 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"Compliant; notification - roles [role-policy-e2e] in namespace default missing "+
+					"as expected, therefore this Object template is compliant",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default existed, "+
+					"and was deleted successfully",
+				"NonCompliant; violation - roles found: [role-policy-e2e] in namespace default",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default missing "+
+					"as expected, therefore this Object template is compliant",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)
@@ -361,9 +449,34 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 			Expect(err).To(BeNil())
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.NonCompliant)
 		})
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in "+
+					"namespace default found but not as specified",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in "+
+					"namespace default found but not as specified",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in "+
+					"namespace default found but not as specified",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"NonCompliant; violation - roles not found: [role-policy-e2e] in namespace default missing",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)
@@ -489,9 +602,47 @@ var _ = Describe("Test configuration policy", Ordered, func() {
 
 			common.DoRootComplianceTest(rolePolicyName, policiesv1.Compliant)
 		})
+		It("the messages from histry should match when policy is mustonlyhave enforce", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(rolePolicyName,
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"found as specified, therefore this Object template is compliant",
+				"Compliant; notification - roles [role-policy-e2e] in "+
+					"namespace default was updated successfully",
+				"NonCompliant; violation - No instances of `roles` "+
+					"found as specified in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] "+
+					"in namespace default was updated successfully",
+				"NonCompliant; violation - No instances of `roles` "+
+					"found as specified in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] "+
+					"in namespace default was updated successfully",
+				"NonCompliant; violation - No instances of `roles` "+
+					"found as specified in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] in namespace default "+
+					"was missing, and was created successfully",
+				"NonCompliant; violation - No instances of `roles` "+
+					"found as specified in namespaces: default",
+				"Compliant; notification - roles [role-policy-e2e] in "+
+					"namespace default was missing, and was created successfully",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the role, policy, and events on managed cluster")
 			common.DoCleanupPolicy(rolePolicyYaml, common.GvrConfigurationPolicy)
 			_, err := common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--all",
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcHub(
+				"delete", "events", "-n", "managed",
+				"--all",
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
 				"delete", "role", "-n", "default", roleName,
 				"--ignore-not-found",
 			)

--- a/test/e2e/iam_policy_test.go
+++ b/test/e2e/iam_policy_test.go
@@ -36,8 +36,34 @@ var _ = Describe("Test iam policy", func() {
 			Expect(err).To(BeNil())
 			common.DoRootComplianceTest(iamPolicyName, policiesv1.Compliant)
 		})
+		It("the messages from histry should match", func() {
+			By("the policy should have matched history after all these test")
+			common.DoHistoryUpdatedTest(iamPolicyName,
+				"Compliant; The number of users with the cluster-admin role is at least 0 above the specified limit",
+				"NonCompliant; The number of users with the cluster-admin role is at least 1 above the specified limit",
+				"Compliant; The number of users with the cluster-admin role is at least 0 above the specified limit",
+			)
+		})
 		AfterAll(func() {
+			By("Deleting the policy and events on managed cluster")
 			common.DoCleanupPolicy(iamPolicyYaml, common.GvrIamPolicy)
+			_, err := common.OcManaged(
+				"delete", "-f", "../resources/iam_policy/clusterrolebinding.yaml",
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
+				"delete", "clusterrolebinding",
+				"e2e-test",
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcManaged(
+				"delete", "events", "-n", "managed",
+				"--all",
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Yi Rae Kim <yikim@redhat.com>

from ACM-3075
GRC Policies have tests that check for a compliance or noncompliance and then some action is taken so that the compliance state changes.  It would be useful after one of these tests, to take a look at the compliance history and see if it was updated as expected. 

This has been proposed as the result of sprint retrospective discussion.

