### PR TITLE
Use a common GitOps user for generator tests

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -41,6 +41,7 @@ var (
 	clientHubDynamic      dynamic.Interface
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
+	gitopsUser            common.OCPUser
 
 	canCreateOpenshiftNamespacesInitialized bool
 	canCreateOpenshiftNamespacesResult      bool
@@ -86,6 +87,9 @@ var _ = BeforeSuite(func() {
 		}, metav1.CreateOptions{})).NotTo(BeNil())
 	}
 	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
+
+	By("Setting up GitOps user")
+	gitopsUser = common.GitOpsUserSetup()
 })
 
 var _ = AfterSuite(func() {
@@ -101,6 +105,8 @@ var _ = AfterSuite(func() {
 		"pod-that-does-not-exist", "--ignore-not-found",
 	)
 	Expect(err).To(BeNil())
+
+	common.GitOpsCleanup(gitopsUser)
 })
 
 func canCreateOpenshiftNamespaces() bool {

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -17,16 +17,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"with a remote Kustomize directory", Ordered, Label("SVT"), func() {
 	const policyName = "e2e-grc-remote-policy-app"
 	const namespace = "grc-e2e-remote-policy-generator"
-	const usernameSuffix = "remotepolgen"
-	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
-		By("Creating and setting up the GitOps user")
-		ocpUser = common.GitOpsUserSetup(namespace, usernameSuffix)
-
 		By("Creating the application subscription")
 		_, err := common.OcUser(
-			ocpUser,
+			gitopsUser,
 			"apply",
 			"-f",
 			"../resources/policy_generator/subscription-remote.yaml",
@@ -107,7 +102,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	})
 
 	AfterAll(func() {
-		By("Cleaning up the changes made to the cluster in the test")
-		common.GitOpsCleanup(namespace, ocpUser)
+		common.CleanupHubNamespace(namespace)
 	})
 })

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -17,16 +17,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	"in an App subscription", Ordered, Label("BVT"), func() {
 	const policyName = "e2e-grc-policy-app"
 	const namespace = "grc-e2e-policy-generator"
-	const usernameSuffix = "polgen"
-	var ocpUser common.OCPUser
 
 	It("Sets up the application subscription", func() {
-		By("Creating and setting up the GitOps user")
-		ocpUser = common.GitOpsUserSetup(namespace, usernameSuffix)
-
 		By("Creating the application subscription")
 		_, err := common.OcUser(
-			ocpUser,
+			gitopsUser,
 			"apply",
 			"-f",
 			"../resources/policy_generator/subscription.yaml",
@@ -126,7 +121,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 	})
 
 	AfterAll(func() {
-		By("Cleaning up the changes made to the cluster in the test")
-		common.GitOpsCleanup(namespace, ocpUser)
+		common.CleanupHubNamespace(namespace)
 	})
 })


### PR DESCRIPTION
This should reduce flakiness caused by the auth pods restarting each time we create a new gitops user.

Refs:
 - https://issues.redhat.com/browse/ACM-2423

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>