### PR TITLE
Update VERSION_TAG to latest-2.8

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -94,9 +94,6 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::make kind-bootstrap-cluster"
-        if [[ "${RELEASE_BRANCH}" != "main" ]]; then
-          export VERSION_TAG=latest-${RELEASE_BRANCH#*-}
-        fi
         make kind-bootstrap-cluster
         echo "::endgroup::"
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deployOnHub ?= false
 RELEASE_BRANCH ?= main
 OCM_API_COMMIT ?= $(shell awk '/open-cluster-management.io\/api/ {print $$2}' go.mod)
 DOCKER_URI ?= quay.io/stolostron
-VERSION_TAG ?= latest
+VERSION_TAG ?= latest-2.8
 
 # GITHUB_USER containing '@' char must be escaped with '%40'
 GITHUB_USER := $(shell echo $(GITHUB_USER) | sed 's/@/%40/g')


### PR DESCRIPTION
In favor of setting the tag directly, this reverts:
- #558 

https://issues.redhat.com/browse/ACM-3490