### PR TITLE
Add basic tests for ACM Policies in hosted mode in the policy framework E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,10 @@ on:
       - release-2.[7-9]
 
 jobs:
+  kind-tests-hosted-mode:
+    name: Framework KinD hosted mode Workflow
+    uses: ./.github/workflows/kind_host.yml
+  
   kind-tests:
     name: Framework KinD # Part of the check name, be careful when changing.
     uses: ./.github/workflows/kind.yml

--- a/.github/workflows/kind_host.yml
+++ b/.github/workflows/kind_host.yml
@@ -1,0 +1,138 @@
+name: Framework KinD Hosted mode Workflow
+
+on:
+  workflow_call:
+    inputs: # To specify where they're located for components, it's leveraged by our controller repos.
+      hub_only_component:
+        required: false
+        type: string
+        default: 'false'
+
+env:
+  RELEASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: Hosted mode Tests # Part of the check name, be careful when changing.
+
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+
+    steps:
+
+    - name: Checkout Component Repository
+      # Checkout a specific component when called from another repository
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      uses: actions/checkout@v3
+      with:
+        # `repository` is inferred as the "caller" repository 
+        path: component
+        # `ref` is inferred as the new commit in the "caller" repository
+
+    - name: Checkout Policy Framework
+      # Checkout a stable branch when called from another repository
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      uses: actions/checkout@v3
+      with:
+        repository: stolostron/governance-policy-framework
+        path: framework
+        ref: ${{ env.RELEASE_BRANCH }} # like main or release-*
+
+    - name: Checkout Policy Framework
+      # Checkout like "usual" when called from this repository
+      if: ${{ github.event.repository.name == 'governance-policy-framework' }}
+      uses: actions/checkout@v3
+      with:
+        # `repository` is inferred as the "caller" repository 
+        path: framework
+        # `ref` is inferred as the new commit
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: framework/go.mod
+
+    - name: Bootstrap the KinD clusters for hosted mode
+      working-directory: framework
+      run: |
+        echo "::group::make e2e-dependencies"
+        make e2e-dependencies
+        echo "::endgroup::"
+
+        echo "::group::make setup hosted mode"
+        make kind-bootstrap-hosted
+        echo "::endgroup::"
+        echo "::group::Saving kubeconfig paths for use in other steps"
+    
+        echo "MANAGED_KUBECONFIG=$(pwd)/kubeconfig_managed" >> $GITHUB_ENV
+        echo "HUB_KUBECONFIG=$(pwd)/kubeconfig_hub" >> $GITHUB_ENV
+        echo "HUB_INTERNAL_KUBECONFIG=$(pwd)/kubeconfig_hub_internal" >> $GITHUB_ENV
+        echo "::endgroup::"
+    
+        echo "::group::test for patch step"
+        export MANAGED_CONFIG=$(pwd)/kubeconfig_managed
+        export HUB_CONFIG=$(pwd)/kubeconfig_hub
+        export HUB_CONFIG_INTERNAL=$(pwd)/kubeconfig_hub_internal
+        echo "::endgroup::"
+
+    - name: Patch Component Image
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      working-directory: component
+      env:
+        WATCH_NAMESPACE: cluster2-hosted
+      run: |
+        if [ "$RELEASE_BRANCH" != main ]; then
+          export VERSION_TAG=latest-$(echo $RELEASE_BRANCH | cut -d'-' -f 2):
+        else
+          export VERSION_TAG=latest
+        fi
+
+        echo "Use $VERSION_TAG"
+
+        echo " KIND_NAME=policy-addon-ctrl1 and the hub config as the default kubeconfig"
+
+        echo "Using KIND_NAME=policy-addon-ctrl1 and the hub config as the default kubeconfig"
+        export KIND_NAME=policy-addon-ctrl1
+        export KUBECONFIG=${HUB_KUBECONFIG}
+
+        echo "::group::make build-images"
+        TAG=$(VERSION_TAG) make build-images
+        echo "::endgroup::"
+
+        echo "::group::make kind-deploy-controller-dev"
+        TAG=$(VERSION_TAG) KIND_NAMESPACE=cluster2-hosted make kind-deploy-controller-dev
+        echo "::endgroup::"
+
+    - name: Run e2e tests
+      working-directory: framework
+      env:
+        TEST_ARGS: --json-report=report.json --junit-report=report.xml --output-dir=test-output
+      run: |
+        make e2e-test-hosted
+
+    - name: Debug
+      if: ${{ failure() }}
+      working-directory: framework
+      run: |
+        make e2e-debug-kind
+        tar -czvf e2e-debug.tar.gz test-output/debug
+    
+    - name: Upload Debug Artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: fw-kind-debug-hosted-mode
+        path: framework/e2e-debug.tar.gz
+
+    - name: Upload Test Reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: fw-kind-report-hosted-mode
+        path: |
+          framework/test-output/report.xml
+          framework/test-output/report.json

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ vendor/
 # Log files from build/periodic.sh
 *-errors.log
 install.sh
+
+governance-policy-addon-controller/

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Test cert policy", func() {
 			Expect(err).To(BeNil())
 			common.DoRootComplianceTest(certPolicyName, policiesv1.Compliant)
 		})
-		It("the messages from histry should match", func() {
+		It("the messages from history should match", func() {
 			By("the policy should have matched history after all these test")
 			common.DoHistoryUpdatedTest(certPolicyName,
 				"Compliant",
@@ -223,12 +223,24 @@ var _ = Describe("Test cert policy", func() {
 			)
 			Expect(err).To(BeNil())
 
-			_, err = common.OcManaged(
-				"delete", "events", "-n", "managed",
-				"--all",
+			_, err = common.OcHosting(
+				"delete", "events", "-n", common.ClusterNamespace,
+				"--field-selector=involvedObject.name="+certPolicyName,
 				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
+			_, err = common.OcHosting(
+				"delete", "events", "-n", common.ClusterNamespace,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+certPolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcHub(
+				"delete", "events", "-n", common.ClusterNamespaceOnHub,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+certPolicyName,
+				"--ignore-not-found",
+			)
+			ExpectWithOffset(1, err).To(BeNil())
 		})
 	})
 })

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -20,21 +20,21 @@ import (
 func configPolicyTestCleanUp(roleName, rolePolicyName, rolePolicyYAML string) {
 	By("Deleting the role, policy, and events on managed cluster")
 	common.DoCleanupPolicy(rolePolicyYAML, common.GvrConfigurationPolicy)
-	_, err := common.OcManaged(
-		"delete", "events", "-n", "managed",
+	_, err := common.OcHosting(
+		"delete", "events", "-n", common.ClusterNamespace,
 		"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
+		"--ignore-not-found",
+	)
+	ExpectWithOffset(1, err).To(BeNil())
+	_, err = common.OcHosting(
+		"delete", "events", "-n", common.ClusterNamespace,
+		"--field-selector=involvedObject.name="+rolePolicyName,
 		"--ignore-not-found",
 	)
 	ExpectWithOffset(1, err).To(BeNil())
 	_, err = common.OcHub(
-		"delete", "events", "-n", "managed",
+		"delete", "events", "-n", common.ClusterNamespaceOnHub,
 		"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
-		"--ignore-not-found",
-	)
-	ExpectWithOffset(1, err).To(BeNil())
-	_, err = common.OcManaged(
-		"delete", "events", "-n", "managed",
-		"--field-selector=involvedObject.name="+rolePolicyName,
 		"--ignore-not-found",
 	)
 	ExpectWithOffset(1, err).To(BeNil())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 var (
 	userNamespace         string
 	clusterNamespace      string
+	clusterNamespaceOnHub string
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
@@ -30,6 +31,8 @@ var (
 	clientHubDynamic      dynamic.Interface
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
+	clientHosting         kubernetes.Interface
+	clientHostingDynamic  dynamic.Interface
 )
 
 func TestE2e(t *testing.T) {
@@ -51,18 +54,21 @@ var _ = test.PolicyOrdering()
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
-	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged)
+
+	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged, common.IsHosted)
 
 	kubeconfigHub = common.KubeconfigHub
 	kubeconfigManaged = common.KubeconfigManaged
 	userNamespace = common.UserNamespace
 	clusterNamespace = common.ClusterNamespace
 	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
-
+	clusterNamespaceOnHub = common.ClusterNamespaceOnHub
 	clientHub = common.ClientHub
 	clientHubDynamic = common.ClientHubDynamic
 	clientManaged = common.ClientManaged
 	clientManagedDynamic = common.ClientManagedDynamic
+	clientHosting = common.ClientHosting
+	clientHostingDynamic = common.ClientHostingDynamic
 
 	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()

--- a/test/e2e/hub_templates_encryption_test.go
+++ b/test/e2e/hub_templates_encryption_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 		It("Should use encryption in the replicated policy", func() {
 			By("Verifying the replicated policy")
 			managedplc := utils.GetWithTimeout(
-				clientManagedDynamic,
+				clientHostingDynamic,
 				common.GvrPolicy,
 				userNamespace+"."+policyName,
 				clusterNamespace,
@@ -145,7 +145,7 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 		})
 
 		It("Verifies that the key can be rotated", func() {
-			encryptionSecret, err := clientHub.CoreV1().Secrets(clusterNamespace).Get(
+			encryptionSecret, err := clientHub.CoreV1().Secrets(clusterNamespaceOnHub).Get(
 				ctx, "policy-encryption-key", metav1.GetOptions{},
 			)
 			Expect(err).To(BeNil())
@@ -153,13 +153,14 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 
 			// Trigger a key rotation
 			encryptionSecret.Annotations[lastRotatedAnnotation] = ""
-			_, err = clientHub.CoreV1().Secrets(clusterNamespace).Update(ctx, encryptionSecret, metav1.UpdateOptions{})
+			_, err = clientHub.CoreV1().Secrets(clusterNamespaceOnHub).
+				Update(ctx, encryptionSecret, metav1.UpdateOptions{})
 			Expect(err).To(BeNil())
 
 			// Wait until the "last-rotated" annotation is set to indicate the key has been rotated
 			Eventually(
 				func() interface{} {
-					encryptionSecret, err = clientHub.CoreV1().Secrets(clusterNamespace).Get(
+					encryptionSecret, err = clientHub.CoreV1().Secrets(clusterNamespaceOnHub).Get(
 						ctx, "policy-encryption-key", metav1.GetOptions{},
 					)
 					Expect(err).To(BeNil())
@@ -177,7 +178,7 @@ var _ = Describe("Test Hub Template Encryption", Ordered, func() {
 			// Wait until the "trigger-update" annotation has been set on the policy
 			expectedTriggerUpdate := fmt.Sprintf(
 				"rotate-key-%s-%s",
-				clusterNamespace,
+				clusterNamespaceOnHub,
 				encryptionSecret.Annotations[lastRotatedAnnotation],
 			)
 

--- a/test/e2e/iam_policy_test.go
+++ b/test/e2e/iam_policy_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Test iam policy", func() {
 			Expect(err).To(BeNil())
 			common.DoRootComplianceTest(iamPolicyName, policiesv1.Compliant)
 		})
-		It("the messages from histry should match", func() {
+		It("the messages from history should match", func() {
 			By("the policy should have matched history after all these test")
 			common.DoHistoryUpdatedTest(iamPolicyName,
 				"Compliant; The number of users with the cluster-admin role is at least 0 above the specified limit",
@@ -58,12 +58,24 @@ var _ = Describe("Test iam policy", func() {
 				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
-			_, err = common.OcManaged(
-				"delete", "events", "-n", "managed",
-				"--all",
+			_, err = common.OcHosting(
+				"delete", "events", "-n", common.ClusterNamespace,
+				"--field-selector=involvedObject.name="+iamPolicyName,
 				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
+			_, err = common.OcHosting(
+				"delete", "events", "-n", common.ClusterNamespace,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+iamPolicyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+			_, err = common.OcHub(
+				"delete", "events", "-n", common.ClusterNamespaceOnHub,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+iamPolicyName,
+				"--ignore-not-found",
+			)
+			ExpectWithOffset(1, err).To(BeNil())
 		})
 	})
 })

--- a/test/e2e/policySet_e2e_test.go
+++ b/test/e2e/policySet_e2e_test.go
@@ -40,15 +40,15 @@ var _ = Describe("Test policy set", func() {
 				clientHubDynamic, common.GvrPlacementRule, testPolicySetName+"-plr", userNamespace,
 				true, defaultTimeoutSeconds,
 			)
-			plr.Object["status"] = utils.GeneratePlrStatus(clusterNamespace)
+			plr.Object["status"] = utils.GeneratePlrStatus(clusterNamespaceOnHub)
 			_, err = clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(
 				context.TODO(), plr, metav1.UpdateOptions{},
 			)
 			Expect(err).To(BeNil())
 
-			By("Checking " + testPolicyName + " on managed cluster in ns " + clusterNamespace)
+			By("Checking " + testPolicyName + " on managed cluster in ns " + clusterNamespaceOnHub)
 			managedplc := utils.GetWithTimeout(
-				clientHubDynamic, common.GvrPolicy, userNamespace+"."+testPolicyName, clusterNamespace, true,
+				clientHubDynamic, common.GvrPolicy, userNamespace+"."+testPolicyName, clusterNamespaceOnHub, true,
 				defaultTimeoutSeconds,
 			)
 			Expect(managedplc).NotTo(BeNil())

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -60,8 +60,7 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	By("Setup hub and managed client")
-	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged)
-
+	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged, false)
 	kubeconfigHub = common.KubeconfigHub
 	kubeconfigManaged = common.KubeconfigManaged
 	userNamespace = common.UserNamespace

--- a/test/policy_ordering.go
+++ b/test/policy_ordering.go
@@ -60,7 +60,7 @@ func PolicyOrdering(labels ...string) bool {
 	}
 
 	Describe("GRC: [P1][Sev1][policy-grc] Test policy ordering", Ordered, Label(labels...), func() {
-		Describe("Ordering via a dependency on a Policy", func() {
+		Describe("Ordering via a dependency on a Policy", Ordered, func() {
 			BeforeAll(func() {
 				By("Creating the initial policy to use as a dependency")
 				DoCreatePolicyTest(initialPolicyYaml, GvrConfigurationPolicy)
@@ -83,7 +83,7 @@ func PolicyOrdering(labels ...string) bool {
 			})
 			AfterAll(cleanup)
 		})
-		Describe("Ordering via an extraDependency on a ConfigurationPolicy", func() {
+		Describe("Ordering via an extraDependency on a ConfigurationPolicy", Ordered, func() {
 			BeforeAll(func() {
 				By("Creating the initial policy to use as a dependency")
 				DoCreatePolicyTest(initialPolicyYaml, GvrConfigurationPolicy)
@@ -106,7 +106,7 @@ func PolicyOrdering(labels ...string) bool {
 			})
 			AfterAll(cleanup)
 		})
-		Describe("IgnorePending should allow policies to be compliant when one template is pending", func() {
+		Describe("IgnorePending should allow policies to be compliant when one template is pending", Ordered, func() {
 			BeforeAll(func() {
 				By("Creating the initial policy to use as a dependency")
 				DoCreatePolicyTest(initialPolicyYaml, GvrConfigurationPolicy)
@@ -126,7 +126,7 @@ func PolicyOrdering(labels ...string) bool {
 			})
 			AfterAll(cleanup)
 		})
-		Describe("Ordering via a dependency on a PolicySet", func() {
+		Describe("Ordering via a dependency on a PolicySet", Ordered, func() {
 			It("Should create policyset with noncompliant status", func() {
 				By("Creating the initial policy set to use as a dependency")
 				_, err := OcHub("apply", "-f", testPolicySetYaml, "-n", UserNamespace)
@@ -142,15 +142,15 @@ func PolicyOrdering(labels ...string) bool {
 					ClientHubDynamic, GvrPlacementRule, testPolicySetName+"-plr", UserNamespace,
 					true, DefaultTimeoutSeconds,
 				)
-				plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespace)
+				plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespaceOnHub)
 				_, err = ClientHubDynamic.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
 					context.TODO(), plr, metav1.UpdateOptions{},
 				)
 				Expect(err).To(BeNil())
 
-				By("Checking " + testPolicyName + " on managed cluster in ns " + ClusterNamespace)
+				By("Checking " + testPolicyName + " on managed cluster in ns " + ClusterNamespaceOnHub)
 				managedplc := utils.GetWithTimeout(
-					ClientHubDynamic, GvrPolicy, UserNamespace+"."+testPolicyName, ClusterNamespace, true,
+					ClientHubDynamic, GvrPolicy, UserNamespace+"."+testPolicyName, ClusterNamespaceOnHub, true,
 					DefaultTimeoutSeconds,
 				)
 				Expect(managedplc).NotTo(BeNil())
@@ -199,7 +199,6 @@ func PolicyOrdering(labels ...string) bool {
 					"pod-dne", "--ignore-not-found",
 				)
 				Expect(err).To(BeNil())
-
 				DoRootComplianceTest(plcWithDepOnSetName, policiesv1.Pending)
 			})
 			AfterAll(cleanup)

--- a/test/resources/hosted_mode/managed-cluster-addon.yaml
+++ b/test/resources/hosted_mode/managed-cluster-addon.yaml
@@ -1,0 +1,43 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: governance-policy-framework
+  annotations:
+    addon.open-cluster-management.io/hosting-cluster-name: cluster1
+spec:
+  installNamespace: cluster2-hosted
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: config-policy-controller
+  annotations:
+    addon.open-cluster-management.io/hosting-cluster-name: cluster1
+    addon.open-cluster-management.io/values: '{"global":{"imageOverrides":{"config_policy_controller":"quay.io/stolostron/config-policy-controller:imagetag"}}}'
+
+spec:
+  installNamespace: cluster2-hosted
+---
+
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: cert-policy-controller
+  annotations:
+    addon.open-cluster-management.io/hosting-cluster-name: cluster1
+    addon.open-cluster-management.io/values: '{"args": {"frequency": 10}, "global":{"imageOverrides":{"cert_policy_controller":"quay.io/stolostron/cert-policy-controller:imagetag"}}}'
+
+spec:
+  installNamespace: cluster2-hosted
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: iam-policy-controller
+  namespace: cluster2
+  annotations:
+    addon.open-cluster-management.io/hosting-cluster-name: cluster1
+    addon.open-cluster-management.io/values: '{"args": {"frequency": 10}, "global":{"imageOverrides":{"iam_policy_controller":"quay.io/stolostron/iam-policy-controller:imagetag"}}}'
+spec:
+  installNamespace: cluster2-hosted
+


### PR DESCRIPTION
Add basic tests for ACM Policies in hosted mode in the policy framework E2E tests
We currently test that hosted mode deployments of the policy controllers work as expected on PRs to the Policy Addon controller. This is good for testing changes in how the controllers are deployed but it doesn't test their functionality in hosted mode and it also doesn't gate code changes the policy controllers.

GRC currently has E2E and other integration tests in the stolostron/governance-policy-framework repo that gate code changes from being fast-forwarded to a release branch and thus getting into a release build. A new E2E test should be added that tests the policy controllers in hosted mode.

Since these E2E tests are already executed on PR CI in the Stolostron repos before an upstream PR is synced, this will act as a gate for controller changes that break hosted mode deployments.
NOTE: 
- hosted mode takes more time than normal mode
- some Mac has issue on Managedclusteraddon
Refs:

https://issues.redhat.com/browse/ACM-3076
Signed-off-by: Yi Rae Kim [yikim@redhat.com](mailto:yikim@redhat.com)