### PR TITLE
Pass a pointer for OCPUser

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func() {
 	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
 
 	By("Setting up GitOps user")
-	gitopsUser = common.GitOpsUserSetup()
+	common.GitOpsUserSetup(&gitopsUser)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
If subscription admin setup (specifically, logging in) fails, cleanup doesn't have the populated OCPUser to work with. Using a pointer populates the values so that cleanup can succeed in that case.