### PR TITLE
Use `VERSION_TAG` in patch

### DIFF
--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -41,7 +41,7 @@ if [[ "${TARGET_BRANCH}" ]] && [[ "${TARGET_BRANCH}" != "main" ]]; then
   VERSION_TAG="${VERSION_TAG}-${PULL_BASE_REF#*-}"
 fi
 
-$DIR/patch-cluster-prow.sh
+VERSION_TAG="${VERSION_TAG}" $DIR/patch-cluster-prow.sh
 cp ${HUB_KUBE} $DIR/../kubeconfig_hub
 cp ${MANAGED_KUBE} $DIR/../kubeconfig_managed
 


### PR DESCRIPTION
Not sure how this got missed previously, but the script somehow wasn't actually using the `VERSION_TAG`.