### PR TITLE
Improve reliability of the prune tests

### DIFF
--- a/test/configuration_policy_prune.go
+++ b/test/configuration_policy_prune.go
@@ -45,6 +45,16 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
+		if cmShouldBeDeleted {
+			By("Checking that the ConfigurationPolicy has a finalizer")
+			Eventually(func() []string {
+				cfgPol := utils.GetWithTimeout(clientManagedDynamic, GvrConfigurationPolicy,
+					policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+
+				return cfgPol.GetFinalizers()
+			}, 30, 5).ShouldNot(BeEmpty())
+		}
+
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
 			clientManagedDynamic,
@@ -75,6 +85,14 @@ func ConfigPruneBehavior(labels ...string) bool {
 		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
 		DoRootComplianceTest(policyName, policiesv1.Compliant)
+
+		By("Checking that the ConfigurationPolicy has a finalizer")
+		Eventually(func() []string {
+			cfgPol := utils.GetWithTimeout(clientManagedDynamic, GvrConfigurationPolicy,
+				policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+
+			return cfgPol.GetFinalizers()
+		}, 30, 5).ShouldNot(BeEmpty())
 
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
@@ -160,6 +178,16 @@ func ConfigPruneBehavior(labels ...string) bool {
 
 		DoRootComplianceTest(policyName, policiesv1.Compliant)
 
+		if cmShouldBeDeleted {
+			By("Checking that the ConfigurationPolicy has a finalizer")
+			Eventually(func() []string {
+				cfgPol := utils.GetWithTimeout(clientManagedDynamic, GvrConfigurationPolicy,
+					policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+
+				return cfgPol.GetFinalizers()
+			}, 30, 5).ShouldNot(BeEmpty())
+		}
+
 		By("Checking that the configmap was created")
 		utils.GetWithTimeout(
 			clientManagedDynamic,
@@ -243,6 +271,16 @@ func ConfigPruneBehavior(labels ...string) bool {
 		DoCreatePolicyTest(policyYaml, GvrConfigurationPolicy)
 
 		DoRootComplianceTest(policyName, policiesv1.Compliant)
+
+		if cmShouldBeDeleted {
+			By("Checking that the ConfigurationPolicy has a finalizer")
+			Eventually(func() []string {
+				cfgPol := utils.GetWithTimeout(clientManagedDynamic, GvrConfigurationPolicy,
+					policyName, ClusterNamespace, true, DefaultTimeoutSeconds)
+
+				return cfgPol.GetFinalizers()
+			}, 30, 5).ShouldNot(BeEmpty())
+		}
 
 		By("Checking the configmap's data was updated")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
Sometimes the finalizer can't be added to the ConfigurationPolicy on the initial reconciliation. When that happens, the test might move too fast, and the managed resource can't be deleted. Now, when the resource should be deleted, the test waits for the finalizer before continuing.