### PR TITLE
Test ManagedClusterLabels in hub templates

### DIFF
--- a/test/integration/hubtemplates_managedclusterlabels_test.go
+++ b/test/integration/hubtemplates_managedclusterlabels_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
+)
+
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test .ManagedClusterLabels in hub templates", Ordered, func() {
+	const resourcesPath = "../resources/hub_templates_managedclusterlabels/"
+
+	Describe("A single-value lookup should work", Ordered, Label("BVT"), func() {
+		const (
+			hubConfigmapYAML     = resourcesPath + "hub-configmap.yaml"
+			policyName           = "mclabels-fromcm-pol"
+			policyYAML           = resourcesPath + policyName + ".yaml"
+			createdConfigmapName = "mclabels-fromcm-created"
+		)
+
+		BeforeAll(func() {
+			By("Creating a configmap on the hub to use in the test")
+			_, err := common.OcHub("apply", "-f="+hubConfigmapYAML, "-n="+userNamespace)
+			Expect(err).To(BeNil())
+		})
+
+		It(policyName+" should be created on the Hub", func() {
+			common.DoCreatePolicyTest(policyYAML, common.GvrConfigurationPolicy)
+		})
+
+		It(policyName+" should be Compliant", func() {
+			common.DoRootComplianceTest(policyName, policiesv1.Compliant)
+		})
+
+		It("Checks that the configmap was created correctly on the managed cluster", func() {
+			value, err := common.OcManaged("get", "configmap", createdConfigmapName, "-n=default",
+				"-o=jsonpath={.data.testvalue}")
+			Expect(err).To(BeNil())
+			Expect(value).To(MatchRegexp("Test Success"))
+		})
+
+		AfterAll(func() {
+			By("Removing the configmap from the hub")
+			_, err := common.OcHub("delete", "-f="+hubConfigmapYAML, "-n="+userNamespace, "--ignore-not-found")
+			Expect(err).To(BeNil())
+
+			By("Removing the policy")
+			common.DoCleanupPolicy(policyYAML, common.GvrConfigurationPolicy)
+
+			By("Removing the configmap from the managed cluster")
+			_, err = common.OcManaged("delete", "configmap", createdConfigmapName, "-n=default", "--ignore-not-found")
+			Expect(err).To(BeNil())
+
+			By("Removing policy events from the managed cluster")
+			_, err = common.OcManaged(
+				"delete", "events", "-n", clusterNamespace,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+policyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("Ranging over all labels on a ManagedCluster should work", Ordered, func() {
+		const (
+			policyName           = "mclabels-range-pol"
+			policyYAML           = resourcesPath + policyName + ".yaml"
+			createdConfigmapName = "mclabels-range-created"
+		)
+
+		It(policyName+" should be created on the Hub", func() {
+			common.DoCreatePolicyTest(policyYAML, common.GvrConfigurationPolicy)
+		})
+
+		It(policyName+" should be Compliant", func() {
+			common.DoRootComplianceTest(policyName, policiesv1.Compliant)
+		})
+
+		It("Checks that the configmap was created correctly on the managed cluster", func() {
+			value, err := common.OcManaged("get", "configmap", createdConfigmapName, "-n=default",
+				"-o=jsonpath={.data}")
+			Expect(err).To(BeNil())
+			Expect(value).To(And( // An arbitrary selection of keys that it should have
+				MatchRegexp("vendor"),
+				MatchRegexp("openshiftVersion"),
+				MatchRegexp("cloud"),
+				MatchRegexp("feature.open-cluster-management.io"),
+			))
+		})
+
+		AfterAll(func() {
+			By("Removing the policy")
+			common.DoCleanupPolicy(policyYAML, common.GvrConfigurationPolicy)
+
+			By("Removing the configmap from the managed cluster")
+			_, err := common.OcManaged("delete", "configmap", createdConfigmapName, "-n=default", "--ignore-not-found")
+			Expect(err).To(BeNil())
+
+			By("Removing policy events from the managed cluster")
+			_, err = common.OcManaged(
+				"delete", "events", "-n", clusterNamespace,
+				"--field-selector=involvedObject.name="+common.UserNamespace+"."+policyName,
+				"--ignore-not-found",
+			)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/test/resources/hub_templates_managedclusterlabels/hub-configmap.yaml
+++ b/test/resources/hub_templates_managedclusterlabels/hub-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mclabels-fromcm-test-cm
+data:
+  OpenShift: Test Success

--- a/test/resources/hub_templates_managedclusterlabels/mclabels-fromcm-pol.yaml
+++ b/test/resources/hub_templates_managedclusterlabels/mclabels-fromcm-pol.yaml
@@ -1,0 +1,52 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: mclabels-fromcm-pol
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mclabels-fromcm-pol
+        spec:
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: mclabels-fromcm-created
+                  namespace: default
+                data:
+                  testvalue: '{{hub fromConfigMap "" "mclabels-fromcm-test-cm" .ManagedClusterLabels.vendor hub}}'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: mclabels-fromcm-pol-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: mclabels-fromcm-pol-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: mclabels-fromcm-pol
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: mclabels-fromcm-pol-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/hub_templates_managedclusterlabels/mclabels-range-pol.yaml
+++ b/test/resources/hub_templates_managedclusterlabels/mclabels-range-pol.yaml
@@ -1,0 +1,54 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: mclabels-range-pol
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mclabels-range-pol
+        spec:
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
+          severity: medium
+          object-templates-raw: |
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: mclabels-range-created
+                  namespace: default
+                data:
+                  {{hub range $rkey, $rval := .ManagedClusterLabels -hub}}
+                  "{{hub $rkey | replace "/" "_" hub}}": "{{hub $rval hub}}"
+                  {{hub end hub}}
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: mclabels-range-pol-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: mclabels-range-pol-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: mclabels-range-pol
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: mclabels-range-pol-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []


### PR DESCRIPTION
One test is added to the BVT, one is SVT-only. I was planning on having an additional test to check that if a label is queried that doesn't exist, then the policy would be non-compliant (I thought that such an error would appear as a template-error), but the Go stdlib `template` inserts `<no value>` in that situation. That might not be ideal, but it's not something to fix at this moment.

Refs:
 - https://issues.redhat.com/browse/ACM-4177