### PR TITLE
Use app instead of name for the fw-addon selector

### DIFF
--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -48,7 +48,7 @@ make install-resources
 
 make kind-deploy-policy-framework
 
-./build/wait_for.sh pod -l name=governance-policy-framework-addon -n open-cluster-management-agent-addon
+./build/wait_for.sh pod -l app=governance-policy-framework-addon -n open-cluster-management-agent-addon
 
 make kind-deploy-policy-controllers
 


### PR DESCRIPTION
The label was changed in a recent commit to the framework-addon.

Refs:
 - https://github.com/stolostron/governance-policy-framework-addon/commit/2c5eacdea6ed5f1e6188ce8974519ea20af3657f#diff-bd3800bb3752e57b831a39f0fbe95304375cccdda87daf525fe9a4a841c66bef