### PR TITLE
Remove policy generator

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -26,8 +26,7 @@ cloneRepos() {
 			stolostron/governance-policy-spec-sync
 			stolostron/governance-policy-status-sync
 			stolostron/governance-policy-template-sync
-			stolostron/policy-collection
-			stolostron/policy-generator-plugin"
+			stolostron/policy-collection"
 		for repo in $REPOS; do
 			echo "Cloning $repo ...."
 			git clone --quiet https://github.com/$repo.git $repo || exit 1


### PR DESCRIPTION
We are seeing an issue in our prow: 
```
fatal: destination path 'stolostron/policy-generator-plugin' already exists and is not an empty directory.
[64](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-stolostron-governance-policy-framework-main-periodic-build/1649292036634841088#1:build-log.txt%3A64)
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"[k8s.io/test-infra/prow/entrypoint/run.go:79](http://k8s.io/test-infra/prow/entrypoint/run.go:79)","func":"[k8s.io/test-infra/prow/entrypoint.Options.Run](http://k8s.io/test-infra/prow/entrypoint.Options.Run)","level":"error","msg":"Error executing test process","severity":"error","time":"2023-04-21T06:07:12Z"}
[65](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-stolostron-governance-policy-framework-main-periodic-build/1649292036634841088#1:build-log.txt%3A65)
error: failed to execute wrapped command: exit status 1
```
The Problem is repo.txt also has  policygenerator