### PR TITLE
Add flag for ocm namespace configuration

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -15,8 +15,15 @@ else
   echo "* Using GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER}"
 fi
 
+if [[ -z ${OCM_NAMESPACE} ]]; then
+  echo "* OCM_NAMESPACE not set, using open-cluster-management"
+  OCM_NAMESPACE="open-cluster-management"
+else
+  echo "* Using OCM_NAMESPACE=${OCM_NAMESPACE}"
+fi
+
 # Run test suite with reporting
-CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE || EXIT_CODE=$?
 
 # Remove Gingko phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -34,6 +34,7 @@ var (
 	UserNamespace          string
 	ClusterNamespace       string
 	ClusterNamespaceOnHub  string
+	OCMNamespace           string
 	DefaultTimeoutSeconds  int
 	ManuallyPatchDecisions bool
 	K8sClient              string
@@ -70,6 +71,7 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&UserNamespace, "user_namespace", "policy-test", "ns on hub to create root policy")
 	flagset.StringVar(&ClusterNamespace, "cluster_namespace", "local-cluster", "cluster ns name")
 	flagset.StringVar(&ClusterNamespaceOnHub, "cluster_namespace_on_hub", "", "cluster ns name on hub")
+	flagset.StringVar(&OCMNamespace, "ocm_namespace", "open-cluster-management", "ns of ocm installation")
 	flagset.IntVar(&DefaultTimeoutSeconds, "timeout_seconds", 30, "Timeout seconds for assertion")
 	flagset.BoolVar(
 		&ManuallyPatchDecisions, "patch_decisions", true,

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -34,6 +34,7 @@ const (
 var (
 	userNamespace         string
 	clusterNamespace      string
+	ocmNS                 string
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
@@ -65,6 +66,7 @@ var _ = BeforeSuite(func() {
 	kubeconfigManaged = common.KubeconfigManaged
 	userNamespace = common.UserNamespace
 	clusterNamespace = common.ClusterNamespace
+	ocmNS = common.OCMNamespace
 	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
 
 	clientHub = common.ClientHub

--- a/test/integration/policy_info_metric_test.go
+++ b/test/integration/policy_info_metric_test.go
@@ -19,7 +19,6 @@ import (
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy_governance_info metric", Ordered, Label("BVT"), func() {
 	const (
 		propagatorMetricsSelector = "component=ocm-policy-propagator"
-		ocmNS                     = "open-cluster-management"
 		metricName                = "policy_governance_info"
 		metricsAccName            = "grc-framework-sa-metrics"
 		metricsTokenYaml          = "../resources/policy_info_metric/metrics_token.yaml"

--- a/test/integration/policy_report_metric_test.go
+++ b/test/integration/policy_report_metric_test.go
@@ -22,7 +22,6 @@ import (
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policyreport_info metric", Ordered, Label("BVT"), func() {
 	const (
-		ocmNS                        = "open-cluster-management"
 		saName                       = "grc-framework-sa"
 		roleBindingName              = "grc-framework-role-binding"
 		saTokenName                  = "grc-framework-sa-token-manual"


### PR DESCRIPTION
The namespace where some of the open-cluster-management resources live is not *always* just "open-cluster-management". It is configurable.

Refs:
 - https://issues.redhat.com/browse/ACM-4970