### PR TITLE
Allow cleaning psp to fail if not installed

### DIFF
--- a/build/clean-up-cluster.sh
+++ b/build/clean-up-cluster.sh
@@ -56,7 +56,7 @@ function managed() {
     oc delete secret grcui-e2e-credential -n default --ignore-not-found
     oc delete LimitRange container-mem-limit-range -n default --ignore-not-found
     oc delete ns prod --ignore-not-found
-    oc delete psp restricted-psp --ignore-not-found
+    oc delete psp restricted-psp --ignore-not-found || true # the podsecuritypolicy API might not exist
     oc delete role deployments-role -n default --ignore-not-found
     oc delete rolebinding operatoruser-rolebinding -n default --ignore-not-found
     oc delete scc restricted-scc --ignore-not-found


### PR DESCRIPTION
Newer versions of kubernetes do not have a PodSecurityPolicy type, so this cleanup script was failing. Now cleaning up that object works like other objects that might not have their types defined on the cluster.