### PR TITLE
Add script for upstream releases

### DIFF
--- a/build/main-branch-sync/README.md
+++ b/build/main-branch-sync/README.md
@@ -1,13 +1,21 @@
 # Automation tools for policy-grc-squad
 
+## Releasing a new version upstream
+
+- **Prerequisites**:
+  - `jq` installed
+  - Write access to the repos
+
+1. Export the new `vX.Y.Z` version to be released to `NEW_RELEASE`.
+2. Run `upstream-release.sh`.
+
 ## Refreshing builds with a no-op PR
 
 - **Prerequisites**:
   - `yq` installed
-  - SSH access to GitHub
   - Write access to the repos
 
-1. Change to the `main-branch-sync/` directory.
+1. Update `repo.txt` to list the repos that require a refresh.
 2. Run the `refresh.sh` script. (It will update the "Date" comment in the README of each repo and
    push a new branch to the repo with the updates and provide a URL to open the PRs.)
 
@@ -40,8 +48,6 @@
   - Log in to the Collective cluster
   - Log in to GitHub with username `acm-grc-security`
 
-1. Change to the `main-branch-sync/` directory.
-2. Run the `rotate-secrets.sh` script. (It will prompt for the new GitHub and SonarCloud tokens,
+1. Run the `rotate-secrets.sh` script. (It will prompt for the new GitHub and SonarCloud tokens,
    regenerate the AWS token, rotate the Collective tokens, rotate the GitHub tokens, and provide
    manual steps to update tokens in Prow, Travis, and Bitwarden.)
-

--- a/build/main-branch-sync/fetch-repo-list.sh
+++ b/build/main-branch-sync/fetch-repo-list.sh
@@ -10,6 +10,11 @@
 #
 ########################
 
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "error: Exporting GITHUB_TOKEN is required to fetch repos."
+  exit 1
+fi
+
 GITHUB_ORG=${GITHUB_ORG:-"open-cluster-management-io"}
 GITHUB_TEAM=${GITHUB_TEAM:-"sig-policy"}
 GITHUB_API_URL="https://api.github.com/orgs/${GITHUB_ORG}/teams/${GITHUB_TEAM}/repos?per_page=100"

--- a/build/main-branch-sync/upstream-release.sh
+++ b/build/main-branch-sync/upstream-release.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+set -e
+
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [[ -z "${NEW_RELEASE}" ]]; then
+  echo "error: Export NEW_RELEASE with the new vX.Y.Z version before running this script."
+  exit 1
+fi
+
+echo "=== Tagging upstream repos with ${NEW_RELEASE}"
+REPOS="$(${SCRIPT_PATH}/fetch-repo-list.sh | grep -v 'collection\|generator\|nucleus')"
+for REPO in ${REPOS}; do
+  echo "* Handling ${REPO} ..."
+  git clone --quiet https://github.com/${REPO}.git ${SCRIPT_PATH}/${REPO}
+  GIT="git -C ${SCRIPT_PATH}/${REPO}"
+  ${GIT} tag -a ${NEW_RELEASE} -m "${NEW_RELEASE}"
+  ${GIT} push origin ${NEW_RELEASE}
+done
+
+echo "=== View the new releases"
+for REPO in ${REPOS}; do
+  echo "* https://github.com/${REPO}/releases/tag/${NEW_RELEASE}"
+done


### PR DESCRIPTION
Adds an `upstream-release.sh` script to push a new tag to upstream controllers. (The GitHub Action in the repo will create the draft release to be published.)