### PR TITLE
Script fixes

### DIFF
--- a/build/codebase-check.sh
+++ b/build/codebase-check.sh
@@ -58,7 +58,7 @@ packageVersioning() {
 	PACKAGES="^go 
 		github.com/onsi/ginkgo"
 
-	rc=0
+	rcode=0
 	for pkg in ${PACKAGES}; do
 		FRAMEWORK_VERSION="$(awk '/'${pkg//\//\\\/}'/ {print $2}' ${DIR}/../go.mod)"
 		REPO_VERSION="$(awk '/'${pkg//\//\\\/}'/ {print $2}' ${COMPONENT_ORG}/${repo}/go.mod)"
@@ -72,11 +72,11 @@ packageVersioning() {
 			echo "****"
 			echo "ERROR: ${pkg/^/} version ${REPO_VERSION} in $repo does not match ${FRAMEWORK_VERSION}" | tee -a ${ERROR_FILE}
 			echo "***"
-			rc=1
+			rcode=1
 		fi
 	done
 
-	return ${rc}
+	return ${rcode}
 }
 
 # Get the diff of CRDs across RHACM

--- a/build/main-branch-sync/README.md
+++ b/build/main-branch-sync/README.md
@@ -44,7 +44,7 @@
 ## Rotating CI secrets
 
 - **Prerequisites**:
-  - CLIs installed: `gh`, `aws`, `oc`, `jq`
+  - CLIs installed: `gh`, `aws`, `oc` >= v4.11, `jq`
   - Log in to the Collective cluster
   - Log in to GitHub with username `acm-grc-security`
 


### PR DESCRIPTION
`codebase-check.sh`

- `rc` exit code was mistakenly being overwritten

`rotate-secrets.sh`

- Add `oc` version check
- Add absolute path for `repo*.txt`
- Add token rotation for framework Actions
