### PR TITLE
Restart the governance-policy-framework addon after Gatekeeper is uninstalled

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -22,8 +22,15 @@ else
   echo "* Using OCM_NAMESPACE=${OCM_NAMESPACE}"
 fi
 
+if [[ -z ${OCM_ADDON_NAMESPACE} ]]; then
+  echo "* OCM_ADDON_NAMESPACE not set, using open-cluster-management-agent-addon"
+  OCM_ADDON_NAMESPACE="open-cluster-management-agent-addon"
+else
+  echo "* Using OCM_ADDON_NAMESPACE=${OCM_ADDON_NAMESPACE}"
+fi
+
 # Run test suite with reporting
-CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE || EXIT_CODE=$?
+CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE -ocm_addon_namespace=$OCM_ADDON_NAMESPACE || EXIT_CODE=$?
 
 # Remove Gingko phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -34,6 +34,7 @@ var (
 	ClusterNamespace       string
 	ClusterNamespaceOnHub  string
 	OCMNamespace           string
+	OCMAddOnNamespace      string
 	DefaultTimeoutSeconds  int
 	ManuallyPatchDecisions bool
 	K8sClient              string
@@ -71,6 +72,12 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&ClusterNamespace, "cluster_namespace", "local-cluster", "cluster ns name")
 	flagset.StringVar(&ClusterNamespaceOnHub, "cluster_namespace_on_hub", "", "cluster ns name on hub")
 	flagset.StringVar(&OCMNamespace, "ocm_namespace", "open-cluster-management", "ns of ocm installation")
+	flagset.StringVar(
+		&OCMAddOnNamespace,
+		"ocm_addon_namespace",
+		"open-cluster-management-agent-addon",
+		"ns of ocm addon installations",
+	)
 	flagset.IntVar(&DefaultTimeoutSeconds, "timeout_seconds", 30, "Timeout seconds for assertion")
 	flagset.BoolVar(
 		&ManuallyPatchDecisions, "patch_decisions", true,

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -35,6 +35,7 @@ var (
 	userNamespace         string
 	clusterNamespace      string
 	ocmNS                 string
+	ocmAddonNS            string
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
@@ -67,6 +68,7 @@ var _ = BeforeSuite(func() {
 	userNamespace = common.UserNamespace
 	clusterNamespace = common.ClusterNamespace
 	ocmNS = common.OCMNamespace
+	ocmAddonNS = common.OCMAddOnNamespace
 	defaultTimeoutSeconds = common.DefaultTimeoutSeconds
 
 	clientHub = common.ClientHub
@@ -125,7 +127,7 @@ func canCreateOpenshiftNamespaces() bool {
 		"create", "ns", "openshift-grc-test",
 		"--kubeconfig="+kubeconfigManaged,
 		"--dry-run=server",
-		"--as=system:serviceaccount:open-cluster-management-agent-addon:config-policy-controller-sa",
+		"--as=system:serviceaccount:"+ocmAddonNS+":config-policy-controller-sa",
 	)
 
 	if strings.Contains(out, "namespace/openshift-grc-test created") {

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -352,5 +352,30 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 			"--ignore-not-found",
 		)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Restart the governance-policy-framework addon after Gatekeeper is uninstalled to disable the Gatekeeper
+		// status controller. This would happen automatically, but it can take a while since it relies on the health
+		// endpoint.
+		_, err = utils.KubectlWithOutput(
+			"-n",
+			ocmAddonNS,
+			"rollout",
+			"restart",
+			"deployment/governance-policy-framework",
+			"--kubeconfig="+kubeconfigManaged,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for the restart to complete.
+		_, err = utils.KubectlWithOutput(
+			"-n",
+			ocmAddonNS,
+			"rollout",
+			"status",
+			"deployment/governance-policy-framework",
+			"--timeout=180s",
+			"--kubeconfig="+kubeconfigManaged,
+		)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This is to disable the Gatekeeper status controller. This would happen automatically, but it can take a while since it relies on the health endpoint.

Relates:
https://issues.redhat.com/browse/ACM-5965