### PR TITLE
Clean up namespaces in AfterSuite

### DIFF
--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -17,6 +17,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+var gitopsTestNamespaces = []string{
+	"grc-e2e-policy-generator",
+	"grc-e2e-remote-policy-generator",
+	"policies",
+}
+
 // GitOpsUserSetup configures a new user to use for the GitOps tests. It updates the provided
 // OCPUser instance, which contains a path to the created kubeconfig file.
 func GitOpsUserSetup(ocpUser *OCPUser) {
@@ -29,12 +35,6 @@ func GitOpsUserSetup(ocpUser *OCPUser) {
 	}
 	ocpUser.ClusterRoleBindings = []string{subAdminBinding}
 	ocpUser.Username = "grc-e2e-subadmin-user"
-
-	gitopsTestNamespaces := []string{
-		"grc-e2e-policy-generator",
-		"grc-e2e-remote-policy-generator",
-		"policies",
-	}
 
 	// Add additional cluster roles for each namespace
 	for _, ns := range gitopsTestNamespaces {
@@ -164,5 +164,9 @@ func GitOpsCleanup(user OCPUser) {
 	err = ClientHub.CoreV1().Secrets("openshift-config").Delete(context.TODO(), user.Username, metav1.DeleteOptions{})
 	if !k8serrors.IsNotFound(err) {
 		ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	}
+
+	for _, ns := range gitopsTestNamespaces {
+		CleanupHubNamespace(ns)
 	}
 }

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -137,8 +137,4 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			1,
 		).Should(BeNil())
 	})
-
-	AfterAll(func() {
-		common.CleanupHubNamespace(namespace)
-	})
 })

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -100,8 +100,4 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			).Should(BeNil())
 		}
 	})
-
-	AfterAll(func() {
-		common.CleanupHubNamespace(namespace)
-	})
 })

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -119,8 +119,4 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			1,
 		).Should(BeNil())
 	})
-
-	AfterAll(func() {
-		common.CleanupHubNamespace(namespace)
-	})
 })


### PR DESCRIPTION
The namespaces are being created in the BeforeSuite but then are cleaned up in each individual test. Moving cleanup to the AfterSuite could help the flakiness but also makes sense overall.

ref: https://issues.redhat.com/browse/ACM-5966

Backlog issue:
- https://github.com/stolostron/backlog/issues/27321