### PR TITLE
Adjust E2E default configurations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches:
       - main
-      - release-2.[7-9]
+      - release-[0-9]+.[0-9]+
   push:
     branches:
       - main
-      - release-2.[7-9]
+      - release-[0-9]+.[0-9]+
 
 jobs:
   kind-tests:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Run e2e tests
       working-directory: framework
       env:
-        TEST_ARGS: --json-report=report.json --junit-report=report.xml --output-dir=test-output
+        TEST_ARGS: --fail-fast --json-report=report.json --junit-report=report.xml --output-dir=test-output
         HOSTED: ${{ matrix.hosted }}
       run: |
         if [[ "${HOSTED}" == "hosted" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -240,9 +240,9 @@ MANAGED_CLUSTER_NAMESPACE ?= managed
 .PHONY: e2e-test
 e2e-test:
 	@if [ -z "$(TEST_FILE)" ]; then\
-		$(GINKGO) -v --no-color $(TEST_ARGS) --fail-fast test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
+		$(GINKGO) -v $(TEST_ARGS) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
 	else\
-		$(GINKGO) -v --no-color $(TEST_ARGS) --fail-fast --focus-file=$(TEST_FILE) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
+		$(GINKGO) -v $(TEST_ARGS) --focus-file=$(TEST_FILE) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
 	fi
 
 .PHONY: e2e-test-hosted
@@ -329,9 +329,9 @@ e2e-debug-dump:
 .PHONY: integration-test
 integration-test:
 	@if [ -z "$(TEST_FILE)" ]; then\
-		$(GINKGO) -v $(TEST_ARGS) --fail-fast test/integration;\
+		$(GINKGO) -v $(TEST_ARGS) test/integration;\
 	else\
-		$(GINKGO) -v $(TEST_ARGS) --fail-fast --focus-file=$(TEST_FILE) test/integration;\
+		$(GINKGO) -v $(TEST_ARGS) --focus-file=$(TEST_FILE) test/integration;\
 	fi
 
 #hosted

--- a/Makefile
+++ b/Makefile
@@ -313,12 +313,17 @@ e2e-debug-acm: e2e-debug
 
 .PHONY: e2e-debug-dump
 e2e-debug-dump:
-	@echo -e "* DEBUG LOG DUMP..."
-	@echo -e "\n=====\n"
-	@for FILE in $$(ls ./$(DEBUG_DIR)/*); do\
-			echo -e "* Log file: $${FILE}\n";\
+	@echo "* DEBUG LOG DUMP..."
+	@echo "====="
+	@for FILE in $$(ls ./$(DEBUG_DIR)/*_get_*.log); do\
+			echo "* Log file: $${FILE}";\
 			cat $${FILE};\
-			echo -e "\n=====\n";\
+			echo "=====";\
+	done
+	@for FILE in $$(ls ./$(DEBUG_DIR)/*_logs_*.log); do\
+			echo "* Log file: $${FILE}";\
+			tail -n 50 $${FILE};\
+			echo "=====";\
 	done
 
 .PHONY: integration-test

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ DEBUG_DIR ?= test-output/debug
 # Test configuration
 TEST_FILE ?=
 TEST_ARGS ?=
+ifdef TEST_FILE
+	TEST_ARGS += --focus-file=$(TEST_FILE)
+endif
 
 include build/common/Makefile.common.mk
 
@@ -239,11 +242,7 @@ MANAGED_CLUSTER_NAMESPACE ?= managed
 
 .PHONY: e2e-test
 e2e-test:
-	@if [ -z "$(TEST_FILE)" ]; then\
-		$(GINKGO) -v $(TEST_ARGS) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
-	else\
-		$(GINKGO) -v $(TEST_ARGS) --focus-file=$(TEST_FILE) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB);\
-	fi
+	$(GINKGO) -v $(TEST_ARGS) test/e2e -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(CLUSTER_NAMESPACE_ON_HUB)
 
 .PHONY: e2e-test-hosted
 e2e-test-hosted: CLUSTER_NAMESPACE_ON_HUB=cluster2 
@@ -328,11 +327,7 @@ e2e-debug-dump:
 
 .PHONY: integration-test
 integration-test:
-	@if [ -z "$(TEST_FILE)" ]; then\
-		$(GINKGO) -v $(TEST_ARGS) test/integration;\
-	else\
-		$(GINKGO) -v $(TEST_ARGS) --focus-file=$(TEST_FILE) test/integration;\
-	fi
+	$(GINKGO) -v $(TEST_ARGS) test/integration
 
 #hosted
 ADDON_CONTROLLER = $(PWD)/.go/governance-policy-addon-controller


### PR DESCRIPTION
- Shorten debug log output (The dump, now that it is fixed, was causing Travis to run out of logging space)
- Remove `--fail-fast` as a default Ginkgo argument 
- Adjust E2E regex to include all releases - (It used to be that we didn't want it to run on 2.6, but now we do want it to run on 2.9+)
- Make `TEST_FILE` usage cleaner