### PR TITLE
Bump GitOps timeouts

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -310,7 +310,7 @@ func CleanupHubNamespace(namespace string) {
 
 			return isNotFound
 		},
-		DefaultTimeoutSeconds*4,
+		DefaultTimeoutSeconds*6,
 		1,
-	).Should(BeTrue())
+	).Should(BeTrue(), fmt.Sprintf("Namespace %s should be deleted.", namespace))
 }

--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -153,11 +153,12 @@ func GitOpsUserSetup(ocpUser *OCPUser) {
 		g.Expect(err).ShouldNot(HaveOccurred())
 
 		newAuthGeneration := authDeployment.Status.ObservedGeneration
-		g.Expect(newAuthGeneration).Should(BeNumerically(">", oldAuthGeneration))
+		g.Expect(newAuthGeneration).Should(BeNumerically(">", oldAuthGeneration),
+			"The OAuth deployment generation should increment.")
 
 		availableReplicas := authDeployment.Status.AvailableReplicas
 		g.Expect(availableReplicas).ShouldNot(BeZero())
-	}, DefaultTimeoutSeconds*6, 1).Should(Succeed())
+	}, DefaultTimeoutSeconds*10, 1).Should(Succeed())
 
 	// Get a kubeconfig logged in as the subscription and local-cluster administrator OpenShift
 	// user.


### PR DESCRIPTION
Bumping timeouts isn't ideal, but in this case (namespace deletion and OAuth configuration), we're waiting on other processes to complete, so we can give this a shot for now. (Though it does make me wonder if I should remove the deployment check instead and just bump the login timeout for simplicity...)