### PR TITLE
Cert-manager version upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ kind-deploy-config-policy-controller:
 .PHONY: kind-deploy-cert-policy-controller
 kind-deploy-cert-policy-controller:
 	@echo installing cert-manager on managed
-	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	@echo installing cert-policy-controller on managed
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/$(RELEASE_BRANCH)/deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 	kubectl apply -f https://raw.githubusercontent.com/stolostron/cert-policy-controller/$(RELEASE_BRANCH)/deploy/operator.yaml -n $(KIND_MANAGED_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
@@ -368,5 +368,5 @@ kind-delete-hosted: $(ADDON_CONTROLLER)
 .PHONY: 
 kind-deploy-cert-manager:
 	@echo installing cert-manager on managed
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(MANAGED_CLUSTER_NAME)
 

--- a/test/resources/cert_policy/certificate.yaml
+++ b/test/resources/cert_policy/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_allow-noncompliant.yaml
+++ b/test/resources/cert_policy/certificate_allow-noncompliant.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_compliant.yaml
+++ b/test/resources/cert_policy/certificate_compliant.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_disallow-noncompliant.yaml
+++ b/test/resources/cert_policy/certificate_disallow-noncompliant.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_expired-ca.yaml
+++ b/test/resources/cert_policy/certificate_expired-ca.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_long-ca.yaml
+++ b/test/resources/cert_policy/certificate_long-ca.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/certificate_long.yaml
+++ b/test/resources/cert_policy/certificate_long.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cert-policy-certificate

--- a/test/resources/cert_policy/issuer.yaml
+++ b/test/resources/cert_policy/issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: cert-policy-issuer


### PR DESCRIPTION
https://github.com/stolostron/governance-policy-propagator/pull/419 The framework test has an issue because of the miss-matching cert-manger version.  Therefore, this PR will upgrade cert-manager to the latest version. 

Ref: https://cert-manager.io/docs/installation/api-compatibility/#alpha--beta-api-versions 
https://issues.redhat.com/browse/ACM-3558