### PR TITLE
Stop patching placement decisions in integration

### DIFF
--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # Run test suite with reporting
-CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE -ocm_addon_namespace=$OCM_ADDON_NAMESPACE || EXIT_CODE=$?
+CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE -ocm_addon_namespace=$OCM_ADDON_NAMESPACE -patch_decisions=false || EXIT_CODE=$?
 
 # Remove Gingko phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then


### PR DESCRIPTION
When the placement-rule controller is running (like it is in *VT or our integration tests), the placement rule does not need to be "manually" patched with placement decisions. Trying to patch the placement rule can lead to conflicts which fail the test.

Refs:
 - https://github.com/stolostron/backlog/issues/27366