### PR TITLE
Fix JSON for Slack message

### DIFF
--- a/.github/workflows/repo-config.yml
+++ b/.github/workflows/repo-config.yml
@@ -56,8 +56,12 @@ jobs:
           FAILURE_ICON="no_entry"
 
           echo "ACTION_RESULT=$([[ "${{ env.CI_EXIT_CODE }}" == 0 ]] && [[ "${{ env.CODEBASE_EXIT_CODE }}" == 0 ]] && echo 0 || echo 1)" >> ${GITHUB_ENV}
-          echo "CI_SUMMARY=\"\`\`\`\n$(cat summary-ci-errors.log)\n\`\`\`\"" >> ${GITHUB_ENV}
-          echo "CODEBASE_SUMMARY=\"\`\`\`\n$(cat summary-codebase-errors.log)\n\`\`\`\"" >> ${GITHUB_ENV}
+          if [[ -f summary-ci-errors.log ]]; then
+            echo "CI_SUMMARY=\n\`\`\`\n$(awk '{printf "%s\\n", $0}' summary-ci-errors.log)\`\`\`" >> ${GITHUB_ENV}
+          fi
+          if [[ -f summary-codebase-errors.log ]]; then
+            echo "CODEBASE_SUMMARY=\n\`\`\`\n$(awk '{printf "%s\\n", $0}' summary-codebase-errors.log)\`\`\`" >> ${GITHUB_ENV}
+          fi
 
           CI_ICON=${SUCCESS_ICON}
           if [[ "${{ env.CI_EXIT_CODE }}" == 1 ]]; then
@@ -103,7 +107,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Codebase health check ${{ env.ACTION_RESULT == 0 && 'succeeded' || 'failed' }}: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts|View workflow run>:\n:${{ env.CI_ICON }}: CI check\n${{ env.CI_SUMMARY }}:${{ env.CODEBASE_ICON }}: Codebase check\n${{ env.CODEBASE_SUMMARY }}"
+                    "text": "Codebase health check ${{ env.ACTION_RESULT == 0 && 'succeeded' || 'failed' }}: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts|View workflow run>\n:${{ env.CI_ICON }}: CI check${{ env.CI_SUMMARY }}\n:${{ env.CODEBASE_ICON }}: Codebase check${{ env.CODEBASE_SUMMARY }}"
                   }
                 }
               ]

--- a/build/codebase-check.sh
+++ b/build/codebase-check.sh
@@ -227,17 +227,15 @@ fi
 
 cleanup
 
-SUMMARY_FILE="${ARTIFACT_DIR}/summary-${ERROR_FILE_NAME}"
-
 echo ""
 echo "****"
 echo "CODEBASE STATUS REPORT"
 echo "***"
 if [ -f ${ERROR_FILE} ]; then
 	# Print the error log to stdout with duplicate lines removed
-	awk '!a[$0]++' ${ERROR_FILE} | tee ${SUMMARY_FILE}
+	awk '!a[$0]++' ${ERROR_FILE} | tee "${ARTIFACT_DIR}/summary-${ERROR_FILE_NAME}"
 else
-	echo "All checks PASSED!" | tee ${SUMMARY_FILE}
+	echo "All checks PASSED!"
 fi
 echo "***"
 

--- a/build/periodic.sh
+++ b/build/periodic.sh
@@ -179,17 +179,15 @@ done
 
 cleanup
 
-SUMMARY_FILE="${ARTIFACT_DIR}/summary-${ERROR_FILE_NAME}"
-
 echo ""
 echo "****"
 echo "CI STATUS REPORT"
 echo "***"
 if [ -f ${ERROR_FILE} ]; then
 	# Print the error log to stdout with duplicate lines removed
-	awk '!a[$0]++' ${ERROR_FILE} | tee ${SUMMARY_FILE}
+	awk '!a[$0]++' ${ERROR_FILE} | tee "${ARTIFACT_DIR}/summary-${ERROR_FILE_NAME}"
 else
-	echo "All checks PASSED!" | tee ${SUMMARY_FILE}
+	echo "All checks PASSED!"
 fi
 echo "***"
 


### PR DESCRIPTION
- Uses `awk` to replace newlines with literal `\n` for the JSON string
- Doesn't create the summary file on success so that nothing extra is posted to Slack in that case