### PR TITLE
Remove deprecated `PlacementRule` for generator tests

### DIFF
--- a/build/clean-up-cluster.sh
+++ b/build/clean-up-cluster.sh
@@ -34,6 +34,7 @@ function hub() {
             oc delete policies.policy.open-cluster-management.io -n $ns --all --ignore-not-found
             oc delete placementbindings.policy.open-cluster-management.io  -n $ns --all --ignore-not-found
             oc delete placementrules.apps.open-cluster-management.io -n $ns --all --ignore-not-found
+            oc delete placements.cluster.open-cluster-management.io -n $ns --all --ignore-not-found
         done
     oc delete ns -l e2e=true --ignore-not-found
     oc delete ns policy-test duplicatetest --ignore-not-found

--- a/test/resources/policy_generator/acm-hardening_subscription.yaml
+++ b/test/resources/policy_generator/acm-hardening_subscription.yaml
@@ -49,19 +49,18 @@ spec:
       kind: PlacementRule
       name: acm-hardening-placement
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
   labels:
     app: acm-hardening
   name: acm-hardening-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: In
-        values:
-          - "true"
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: In
+          values:
+            - "true"

--- a/test/resources/policy_generator/remote-kustomization/policyGenerator.yaml
+++ b/test/resources/policy_generator/remote-kustomization/policyGenerator.yaml
@@ -7,6 +7,13 @@ placementBindingDefaults:
 policyDefaults:
   namespace: grc-e2e-remote-policy-generator
   consolidateManifests: false
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: local-cluster
+        operator: In
+        values:
+        - "true"
 policies:
   - name: e2e-grc-remote-policy-app
     manifests:

--- a/test/resources/policy_generator/subscription-remote.yaml
+++ b/test/resources/policy_generator/subscription-remote.yaml
@@ -1,4 +1,11 @@
 ---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+spec:
+  clusterSet: global
+---
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
@@ -52,19 +59,18 @@ spec:
       kind: PlacementRule
       name: grc-e2e-remote-policy-generator-placement
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
   labels:
-    app: grc-e2e-remote-policy-generator
-  name: grc-e2e-remote-policy-generator-placement
+    app: acm-hardening
+  name: acm-hardening-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: In
-        values:
-          - "true"
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: In
+          values:
+            - "true"

--- a/test/resources/policy_generator/subscription.yaml
+++ b/test/resources/policy_generator/subscription.yaml
@@ -1,4 +1,11 @@
 ---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+spec:
+  clusterSet: global
+---
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
@@ -52,19 +59,18 @@ spec:
       kind: PlacementRule
       name: grc-e2e-policy-generator-placement
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
   labels:
-    app: grc-e2e-policy-generator
-  name: grc-e2e-policy-generator-placement
+    app: acm-hardening
+  name: acm-hardening-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: In
-        values:
-          - "true"
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: In
+          values:
+            - "true"


### PR DESCRIPTION
Uses `Placement` and also instantiates the `ManagedClusterSetBinding` for the policy generator tests.

This PR will need to be followed up by changes to the `grc-e2e-policy-generator-test` repo:
- https://github.com/stolostron/grc-e2e-policy-generator-test/blob/89156af7fa9e24bfc88f7025425457ad0d82d75a/kustomize/policyGenerator.yaml#L13-L14
- https://github.com/stolostron/grc-e2e-policy-generator-test/blob/89156af7fa9e24bfc88f7025425457ad0d82d75a/kustomize/policyGenerator.yaml#L41-L42

ref: https://issues.redhat.com/browse/ACM-9052