### PR TITLE
Fix Prow update script

### DIFF
--- a/build/branch-create/create.sh
+++ b/build/branch-create/create.sh
@@ -28,17 +28,3 @@ do
   ${GIT} checkout -b release-${NEW_VERSION}
   ${GIT} push origin release-${NEW_VERSION}
 done <${path}/repo.txt
-
-# Special handling
-for repo in "stolostron/governance-policy-addon-controller" "stolostron/governance-policy-framework"; do
-  echo "* Updating image tag in Makefile for ${repo} (this will require a pull request) ..."
-  p="${path}/${repo}"
-  git clone git@github.com:${repo}.git ${p}
-  GIT="git -C ${repo}"
-  ${GIT} checkout -b version-tag-${NEW_VERSION}
-  ${SED} -i "s/\(TAG ?= latest-\).*/\1${NEW_VERSION}/" ${p}/Makefile
-  ${GIT} diff
-  ${GIT} commit --signoff -am "Update Makefile image tag to ${NEW_VERSION}"
-  ${GIT} push origin version-tag-${NEW_VERSION}
-  echo "^^^ Please open a pull request to update the tag."
-done

--- a/build/branch-create/update-release.sh
+++ b/build/branch-create/update-release.sh
@@ -102,10 +102,10 @@ for dirpath in ${COMPONENT_LIST}; do
     # Update the 'promotion' stanza
     if [ "$(yq e '.promotion.name' ${NEW_FILENAME})" != "null" ]; then
       # - For the new version:
-      ver="${NEW_VERSION}" yq e '.promotion.name=env(ver)' -i ${NEW_FILENAME}
+      ver="${NEW_VERSION}" yq e '.promotion.name=strenv(ver)' -i ${NEW_FILENAME}
       yq e '.promotion.disabled=true' -i ${NEW_FILENAME}
       # - For the 'main' branch:
-      ver="${NEW_VERSION}" yq e '.promotion.name=env(ver)' -i ${FILE_PREFIX}-main.yaml
+      ver="${NEW_VERSION}" yq e '.promotion.name=strenv(ver)' -i ${FILE_PREFIX}-main.yaml
       # - For the old version, re-enable promotion:
       yq e 'del(.promotion.disabled)' -i ${OLD_FILENAME}
     fi
@@ -115,7 +115,7 @@ for dirpath in ${COMPONENT_LIST}; do
 
     # Handle UI version tag in 'e2e-tests'
     oldver="${OLD_VERSION}" newver="${NEW_VERSION}" \
-    yq e '.tests[] |= select(.as=="e2e-tests").steps.test[].commands |= sub("latest-"+env(oldver), "latest-"+env(newver))' -i ${NEW_FILENAME}
+    yq e '.tests[] |= select(.as=="e2e-tests").steps.test[].commands |= sub("latest-"+strenv(oldver), "latest-"+strenv(newver))' -i ${NEW_FILENAME}
 
     # Add custom YAML to 'tests' stanza (uncomment code below and add the YAML strings to it)
     # if [[ "${CODE_TYPE}" == "go" ]]; then
@@ -130,10 +130,10 @@ for dirpath in ${COMPONENT_LIST}; do
 
   RULES_CONFIG_FILE="${RELEASE_RULES_PATH}/${dirpath}_prowconfig.yaml"
   EXISTING_CONFIG="$(oldver="${OLD_VERSION}" component="${COMPONENT}" \
-    yq e '.branch-protection.orgs.stolostron.repos[env(component)].branches["release-"+env(oldver)]' ${RULES_CONFIG_FILE})"
+    yq e '.branch-protection.orgs.stolostron.repos[strenv(component)].branches["release-"+strenv(oldver)]' ${RULES_CONFIG_FILE})"
   if [ -f "${RULES_CONFIG_FILE}" ] && [ "${EXISTING_CONFIG}" != "null" ]; then
     oldconfig="${EXISTING_CONFIG}" newver="${NEW_VERSION}" component="${COMPONENT}" \
-    yq e '.branch-protection.orgs.stolostron.repos[env(component)] |= .branches["release-"+env(newver)]=env(oldconfig)' -i ${RULES_CONFIG_FILE}
+    yq e '.branch-protection.orgs.stolostron.repos[strenv(component)] |= .branches["release-"+strenv(newver)]=env(oldconfig)' -i ${RULES_CONFIG_FILE}
   else
     echo "* Skipping update for _prowconfig.yaml"
   fi


### PR DESCRIPTION
The trailing zero in 2.10 was getting stripped since it was getting parsed as a float rather than a string.