### PR TITLE
Set commit time for fast-forwarding

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MANAGED_CLUSTER_NAME: "local-cluster"
+    outputs:
+      START_TIME: ${{ steps.start-time.outputs.START_TIME }}
     steps:
+    - name: Set start timestamp
+      id: start-time
+      run: |
+        echo "START_TIME=$(date)" >> "$GITHUB_OUTPUT"
+
     - name: Checkout Policy Framework
       uses: actions/checkout@v3
 
@@ -79,7 +86,7 @@ jobs:
     - name: Checkout Policy Framework
       uses: actions/checkout@v3
     - run: |
-        ./build/main-branch-sync/sync.sh
+        COMMIT_TIME="${{ needs.integration.outputs.START_TIME }}" ./build/main-branch-sync/sync.sh
 
   slack:
     name: Send result to Slack

--- a/build/main-branch-sync/sync.sh
+++ b/build/main-branch-sync/sync.sh
@@ -4,17 +4,33 @@ set -e
 path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 exit_code=0
 CURRENT_VERSION=$(cat ${path}/../../CURRENT_VERSION)
+COMMIT_TIME="${COMMIT_TIME:-"now"}"
+
+echo "* Fast-forwarding repos using commit time '${COMMIT_TIME}' ..."
 
 while IFS="" read -r repo || [ -n "${repo}" ]
 do
-  printf '%s\n' "Updating ${repo} ...."
+  echo "::group::${repo}"
+  echo "* Updating ${repo} ..."
   p="${path}/${repo}"
   git clone https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${repo}.git ${p}
   GIT="git -C ${p}"
-  ${GIT} checkout main
+  TARGET_COMMIT="$(${GIT} rev-list -1 --before="${COMMIT_TIME}" main)"
+  if [[ -z "${TARGET_COMMIT}" ]]; then
+    echo "* ERROR: Failed to fetch commit for ${p}"
+    exit_code=1
+    echo "::endgroup::"
+    continue
+  fi
+  echo "* Checking out 'main@{${COMMIT_TIME}}' ..."
+  ${GIT} -c advice.detachedHead=false checkout ${TARGET_COMMIT}
+  echo "* Checking out 'release-${CURRENT_VERSION}' ..."
   ${GIT} checkout release-${CURRENT_VERSION} || ${GIT} checkout -b release-${CURRENT_VERSION}
-  ${GIT} rebase main
-  ${GIT} push || { exit_code=1; printf '%s\n' "Failed to fast forward ${p}"; }
+  echo "* Fast-forward to 'main@{${COMMIT_TIME}}' ..."
+  ${GIT} merge --ff-only ${TARGET_COMMIT}
+  echo "* Push to 'release-${CURRENT_VERSION}'"
+  ${GIT} push origin release-${CURRENT_VERSION} || { exit_code=1; echo "* ERROR: Failed to fast forward ${p}"; }
+  echo "::endgroup::"
 done <${path}/repo.txt
 
 exit ${exit_code}


### PR DESCRIPTION
The integration tests take a while to run, so there's a small chance untested changes could make it through when fast-forwarding. This update sets the commit to the start time of the tests, only fast-forwarding to that commit.

ref: https://issues.redhat.com/browse/ACM-9154