### PR TITLE
Add `global` clusterset binding permission

### DIFF
--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -55,7 +55,7 @@ func GitOpsUserSetup(ocpUser *OCPUser) {
 				APIGroups:     []string{"cluster.open-cluster-management.io"},
 				Verbs:         []string{"create"},
 				Resources:     []string{"managedclustersets/bind"},
-				ResourceNames: []string{"default"},
+				ResourceNames: []string{"default", "global"},
 			},
 			{
 				APIGroups: []string{"cluster.open-cluster-management.io"},


### PR DESCRIPTION
I'm not sure why, but our ManagedClusterSetBindings are for `global`. For some reason, the webhook is blocking it in 2.7/2.8 but not for the more recent versions. Either way, it's probably needed for all versions.