### PR TITLE
Set `KIND_VERSION` at the job scope

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: localhost:5000
+      KIND_VERSION: ${{ matrix.kind }}
     strategy:
       # Don't skip all tests if one fails - others may still have useful info
       fail-fast: false
@@ -98,7 +99,6 @@ jobs:
       working-directory: framework
       env:
         deployOnHub: ${{ matrix.deployOnHub }}
-        KIND_VERSION: ${{ matrix.kind }}
         HOSTED: ${{ matrix.hosted }}
       run: |
         echo "::group::make e2e-dependencies"


### PR DESCRIPTION
The framework needs it to determine whether to install Gatekeeper.

(This is also a test since I'm not 100% sure whether the `matrix` context is available at this scope, but the docs seem to indicate it is: https://docs.github.com/en/actions/learn-github-actions/contexts#matrix-context)

ref:
- https://github.com/stolostron/governance-policy-framework-addon/pull/238