### PR TITLE
Wait for cert-manager deployments to be Available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,11 @@ deploy-community-policy-framework-managed: deploy-policy-framework-managed-crd-o
 
 .PHONY: kind-deploy-policy-propagator
 kind-deploy-policy-propagator:
-	@echo installing policy-propagator on hub
+	# Installing policy-propagator on hub
 	-kubectl create ns $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
+	# Installing cert-manager (prerequisite for webhook)
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
-	@echo "wait until cert-manager pods are up"
-	kubectl wait deployment -n cert-manager cert-manager --for condition=Available=True --timeout=180s --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
-	kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=180s  --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
+	kubectl wait deployment -n cert-manager -l app.kubernetes.io/instance=cert-manager --for condition=Available=True --timeout=180s --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)
 	curl https://raw.githubusercontent.com/stolostron/governance-policy-propagator/${RELEASE_BRANCH}/deploy/webhook.yaml | \
 		sed 's/namespace: open-cluster-management/namespace: $(KIND_HUB_NAMESPACE)/g' | \
 	 	kubectl apply -f - --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)


### PR DESCRIPTION
Available deployments should be more reliable than Ready pods since it relies on MinReadySeconds
rather than just a Ready status.

Workflow failure ref:

```
  wait until cert-manager pods are up
  kubectl wait deployment -n cert-manager cert-manager --for condition=Available=True --timeout=180s --kubeconfig=/home/runner/work/governance-policy-framework/governance-policy-framework/framework/kubeconfig_hub
  deployment.apps/cert-manager condition met

  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=180s  --kubeconfig=/home/runner/work/governance-policy-framework/governance-policy-framework/framework/kubeconfig_hub
  pod/cert-manager-67459fb8df-phcg2 condition met
  pod/cert-manager-cainjector-75b8b97c87-rj87r condition met
  pod/cert-manager-webhook-5bc98bdbd9-mflfz condition met

  curl https://raw.githubusercontent.com/stolostron/governance-policy-propagator/main/deploy/webhook.yaml | \
  	sed 's/namespace: open-cluster-management/namespace: open-cluster-management/g' | \
   	kubectl apply -f - --kubeconfig=/home/runner/work/governance-policy-framework/governance-policy-framework/framework/kubeconfig_hub
  service/propagator-webhook-service created
  validatingwebhookconfiguration.admissionregistration.k8s.io/propagator-webhook-validating-configuration created
  Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "[https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s](https://cert-manager-webhook.cert-manager.svc/mutate?timeout=10s)": dial tcp 10.96.183.108:443: connect: connection refused
  Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "[https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s](https://cert-manager-webhook.cert-manager.svc/mutate?timeout=10s)": dial tcp 10.96.183.108:443: connect: connection refused

  make: *** [Makefile:145: kind-deploy-policy-propagator] Error 1
  Error: Process completed with exit code 2.
```

Source: https://github.com/stolostron/governance-policy-framework/actions/runs/7448485426/job/20262971289