### PR TITLE
Allow the sdk-go library from OCM

### DIFF
--- a/build/detect-upstream.sh
+++ b/build/detect-upstream.sh
@@ -25,6 +25,7 @@ importexceptions=(
   "klusterlet-addon-controller"
   "library-e2e-go"
   "library-go"
+  "sdk-go"
 )
 
 parse_imports(){


### PR DESCRIPTION
There is no Stolostron equivalent and it's not a dependency of the addon framework.