### PR TITLE
Add a test to detect policy history repeating itself

### DIFF
--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -212,6 +212,31 @@ func GetLatestStatusMessage(policyName string, templateIdx int) func() string {
 	}
 }
 
+func GetDuplicateHistoryMessage(policyName string) string {
+	history, _, err := GetHistoryMessages(policyName, 0)
+	if err != nil {
+		return ""
+	}
+
+	historyMsgs := []string{}
+
+	for _, h := range history {
+		historyItem, _ := h.(map[string]interface{})
+		m, _, _ := unstructured.NestedString(historyItem, "message")
+		historyMsgs = append(historyMsgs, m)
+	}
+
+	for i, m := range historyMsgs {
+		if i > 0 {
+			if m == historyMsgs[i-1] {
+				return m
+			}
+		}
+	}
+
+	return ""
+}
+
 func DoHistoryUpdatedTest(policyName string, messages ...string) {
 	By("Getting policy history")
 

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -196,6 +196,21 @@ var _ = Describe("Test cert policy", func() {
 				"NonCompliant;  1 CA certificates expire in less than 45h0m0s: default:cert-policy-secret",
 			)
 		})
+		It("the messages from history should not repeat", func() {
+			By("Creating ../resources/cert_policy/certificate_disallow-noncompliant.yaml in ns default")
+			_, err := common.OcManaged(
+				"apply", "-f",
+				"../resources/cert_policy/certificate_disallow-noncompliant.yaml",
+				"-n", "default",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			By("the policy should not duplicate messages")
+			Consistently(func() interface{} {
+				msg := common.GetDuplicateHistoryMessage(certPolicyName)
+
+				return msg
+			}, 60, 10).Should(Equal(""))
+		})
 		AfterAll(func() {
 			By("Deleting the resource, policy and events on managed cluster")
 

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -725,6 +725,14 @@ var _ = Describe("Test configuration policy enforce", Ordered, func() {
 			)
 			common.DoHistoryUpdatedTest(rolePolicyName, expectedStatusMsgs...)
 		})
+		It("the messages from history should not repeat", func() {
+			By("the policy should not duplicate messages")
+			Consistently(func() interface{} {
+				msg := common.GetDuplicateHistoryMessage(rolePolicyName)
+
+				return msg
+			}, 20, 5).Should(Equal(""))
+		})
 		AfterAll(func() {
 			configPolicyTestCleanUp(rolePolicyName, rolePolicyYaml)
 		})


### PR DESCRIPTION
Under normal operations of the policy controllers, the policy history details should not repeat.  This can happen though if there is a problem where status updates continually trigger new events even if no status is changing.

Refs:
 - https://issues.redhat.com/browse/ACM-9360