### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
An initial Dependabot configuration to update `action/*` actions (if it works here, I'll sync it to all the repos)