### PR TITLE
CI Updates (Dependabot; Common Makefile)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "actions/*"
+          - "*"

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -93,6 +93,7 @@ fmt: fmt-dependencies
 	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gofmt -s -w
 	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gofumpt -l -w
 	find . -not \( -path "./.go" -prune \) -name "*.go" | xargs gci write --skip-generated -s standard -s default -s "prefix($(shell cat go.mod | head -1 | cut -d " " -f 2))"
+	go mod tidy
 
 ############################################################
 #  Unit Test


### PR DESCRIPTION
- Make a single Dependabot group (I'm not sure it's necessary to separate these initially)
- Add `go mod tidy` to `fmt` in the common Makefile