### PR TITLE
Update the Kind minimum version to match OCP 4.12

### DIFF
--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -118,7 +118,7 @@ KIND_VERSION ?= latest
 # Set the Kind version tag
 ifdef KIND_VERSION
   ifeq ($(KIND_VERSION), minimum)
-    KIND_ARGS = --image kindest/node:v1.19.16
+    KIND_ARGS = --image kindest/node:v1.25.16
   else ifneq ($(KIND_VERSION), latest)
     KIND_ARGS = --image kindest/node:$(KIND_VERSION)
   endif


### PR DESCRIPTION
See:
https://access.redhat.com/articles/7027073
https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html