### PR TITLE
Fix error assertions

### DIFF
--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		// Perform some basic validation on the generated policySet.
 		policies, found, err := unstructured.NestedSlice(policyset.Object, "spec", "policies")
@@ -105,7 +105,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		By("Checking that the policy-managedclusteraddon-available policy " +
 			"was propagated to the local-cluster namespace")
@@ -121,7 +121,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		By("Checking that the policy reports configuration policy was created in the local-cluster namespace")
 		configPolicyRsrc := clientHubDynamic.Resource(common.GvrConfigurationPolicy)
@@ -135,6 +135,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		templates, found, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
 		Expect(err).ShouldNot(HaveOccurred())
@@ -70,8 +70,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 		By("Checking that the policy was propagated to the local-cluster namespace")
 		Eventually(
 			func() error {
-				var err error
-				policy, err = policyRsrc.Namespace("local-cluster").Get(
+				_, err := policyRsrc.Namespace("local-cluster").Get(
 					context.TODO(),
 					namespace+"."+policyName,
 					metav1.GetOptions{},
@@ -81,15 +80,14 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		By("Checking that the configuration policies were created in the local-cluster namespace")
 		configPolicyRsrc := clientHubDynamic.Resource(common.GvrConfigurationPolicy)
 		for _, suffix := range []string{"", "2", "3"} {
 			Eventually(
 				func() error {
-					var err error
-					policy, err = configPolicyRsrc.Namespace("local-cluster").Get(
+					_, err := configPolicyRsrc.Namespace("local-cluster").Get(
 						context.TODO(), policyName+suffix, metav1.GetOptions{},
 					)
 
@@ -97,7 +95,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 				},
 				defaultTimeoutSeconds,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		}
 	})
 })

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds*4,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		// Perform some basic validation on the generated policySet. There isn't a need to do any more
 		// than this since the policy generator unit tests cover this scenario well. This test is
@@ -71,7 +71,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		// Perform some basic validation on the generated policy. There isn't a need to do any more
 		// than this since the policy generator unit tests cover this scenario well. This test is
@@ -91,8 +91,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 		By("Checking that the policy was propagated to the local-cluster namespace")
 		Eventually(
 			func() error {
-				var err error
-				policy, err = policyRsrc.Namespace("local-cluster").Get(
+				_, err := policyRsrc.Namespace("local-cluster").Get(
 					context.TODO(),
 					namespace+"."+policyName,
 					metav1.GetOptions{},
@@ -102,14 +101,13 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds*2,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 
 		By("Checking that the configuration policy was created in the local-cluster namespace")
 		configPolicyRsrc := clientHubDynamic.Resource(common.GvrConfigurationPolicy)
 		Eventually(
 			func() error {
-				var err error
-				policy, err = configPolicyRsrc.Namespace("local-cluster").Get(
+				_, err := configPolicyRsrc.Namespace("local-cluster").Get(
 					context.TODO(), policyName, metav1.GetOptions{},
 				)
 
@@ -117,6 +115,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			},
 			defaultTimeoutSeconds,
 			1,
-		).Should(BeNil())
+		).ShouldNot(HaveOccurred())
 	})
 })

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -133,7 +133,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -106,7 +106,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -128,7 +128,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -116,7 +116,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -130,7 +130,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -121,7 +121,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -101,7 +101,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 		})
 
 		AfterAll(func() {

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 
 			templates, found, err := unstructured.NestedSlice(rootPolicy.Object, "spec", "policy-templates")
 			Expect(err).ShouldNot(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-1.yaml")
@@ -167,7 +167,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 				},
 				defaultTimeoutSeconds*2,
 				1,
-			).Should(BeNil())
+			).ShouldNot(HaveOccurred())
 
 			By("Checking the status of policy set")
 			yamlPlc := utils.ParseYaml("../resources/policy_set/statuscheck-4.yaml")


### PR DESCRIPTION
- Use `HaveOccurred()` consistently
- Ignore unused return values