### PR TITLE
Add integration tests: Helm in the PolicyGenerator

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,8 +35,7 @@ jobs:
         ./build/download-clis.sh
         make e2e-dependencies
         oc login ${{ secrets.E2E_URL }} --insecure-skip-tls-verify=true -u ${{ secrets.E2E_USER }} -p ${{ secrets.E2E_PASSWORD }}
-        cp ${HOME}/.kube/config ./kubeconfig_hub
-        cp ${HOME}/.kube/config ./kubeconfig_managed
+        make e2e-setup-kube
         echo "::endgroup::"
 
         echo "::group::Patch images to latest"

--- a/Makefile
+++ b/Makefile
@@ -292,11 +292,11 @@ e2e-debug-hub:
 	-kubectl get leases -n $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_get_leases_$(KIND_HUB_NAMESPACE).log
 	-kubectl describe pods -n $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_describe_pods_$(KIND_HUB_NAMESPACE).log
 	-kubectl get managedclusteraddon -A -o yaml --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_managedclusteraddon.yaml
-	-for POD in $$(kubectl get pods -n $(KIND_HUB_NAMESPACE) -l name=governance-policy-propagator -o name --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)); do \
+	-for POD in $$(kubectl get pods -n $(KIND_HUB_NAMESPACE) -l "app=multicluster-operators-hub-subscription" -o name --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)); do \
 		PODNAME=$${POD##"pod/"}; \
-	  	kubectl logs $${PODNAME} -c governance-policy-propagator -n $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_logs_$${PODNAME}.log; \
+	  	kubectl logs $${PODNAME} -n $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_logs_$${PODNAME}.log; \
 	done
-	-for POD in $$(kubectl get pods -n $(KIND_HUB_NAMESPACE) -l name=governance-policy-addon-controller -o name --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)); do \
+	-for POD in $$(kubectl get pods -n $(KIND_HUB_NAMESPACE) -l "name in (governance-policy-propagator,governance-policy-addon-controller)" -o name --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME)); do \
 		PODNAME=$${POD##"pod/"}; \
 	  	kubectl logs $${PODNAME} -n $(KIND_HUB_NAMESPACE) --kubeconfig=$(PWD)/kubeconfig_$(HUB_CLUSTER_NAME) > $(DEBUG_DIR)/hub_logs_$${PODNAME}.log; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,12 @@ fmt:
 ############################################################
 # e2e test section
 ############################################################
+.PHONY: e2e-setup-kube
+e2e-setup-kube: KUBECONFIG ?= $(HOME)/.kube/config
+e2e-setup-kube:
+	cp $(KUBECONFIG) kubeconfig_$(HUB_CLUSTER_NAME)
+	cp $(KUBECONFIG) kubeconfig_$(MANAGED_CLUSTER_NAME)
+
 .PHONY: kind-bootstrap-cluster
 kind-bootstrap-cluster: kind-create-clusters install-crds install-resources kind-deploy-policy-framework kind-deploy-policy-controllers
 

--- a/test/common/gitops_utils.go
+++ b/test/common/gitops_utils.go
@@ -19,6 +19,7 @@ import (
 
 var gitopsTestNamespaces = []string{
 	"grc-e2e-policy-generator",
+	"grc-e2e-helm-policy-generator",
 	"grc-e2e-remote-policy-generator",
 	"policies",
 }

--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -67,6 +67,11 @@ var (
 		Version:  "v1",
 		Resource: "placementrules",
 	}
+	GvrSubscription = schema.GroupVersionResource{
+		Group:    "apps.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "subscriptions",
+	}
 	GvrK8sRequiredLabels = schema.GroupVersionResource{
 		Group:    "constraints.gatekeeper.sh",
 		Version:  "v1beta1",

--- a/test/integration/policy_generator_acm_hardening_test.go
+++ b/test/integration/policy_generator_acm_hardening_test.go
@@ -54,6 +54,21 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the ACM Hardening "+
 			namespace,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			appSubRsrc, err := clientHubDynamic.Resource(common.GvrSubscription).Namespace(namespace).Get(
+				context.TODO(), "acm-hardening-subscription", metav1.GetOptions{},
+			)
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription should exist.")
+
+			appSubPhase, found, err := unstructured.NestedString(appSubRsrc.Object, "status", "phase")
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription status should be parseable.")
+			g.Expect(found).Should(BeTrue(), "The subscription status should have a phase.")
+			g.Expect(appSubPhase).Should(Equal("Propagated"), "The subscription should propagate successfully.")
+		},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
 	})
 
 	It("Validates the propagated policies", func() {

--- a/test/integration/policy_generator_helm_test.go
+++ b/test/integration/policy_generator_helm_test.go
@@ -1,0 +1,131 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
+)
+
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
+	"with a Helm chart", Ordered, Label("SVT"), func() {
+	const policyName = "e2e-grc-helm-policy-app"
+	const namespace = "grc-e2e-helm-policy-generator"
+
+	It("Sets up the application subscription", func(ctx SpecContext) {
+		By("Creating the application subscription")
+		_, err := common.OcUser(
+			gitopsUser,
+			"apply",
+			"-f",
+			"../resources/policy_generator/subscription-helm.yaml",
+			"-n",
+			namespace,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			appSubRsrc, err := clientHubDynamic.Resource(common.GvrSubscription).Namespace(namespace).Get(
+				ctx, "grc-e2e-helm-policy-generator-subscription", metav1.GetOptions{},
+			)
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription should exist.")
+
+			appSubPhase, found, err := unstructured.NestedString(appSubRsrc.Object, "status", "phase")
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription status should be parseable.")
+			g.Expect(found).Should(BeTrue(), "The subscription status should have a phase.")
+			g.Expect(appSubPhase).Should(Equal("Propagated"), "The subscription should propagate successfully.")
+		},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
+	})
+
+	It("Validates the propagated policies", func(ctx SpecContext) {
+		// Perform some basic validation on the generated policy.
+		By("Checking that the root policy was created")
+		policyRsrc := clientHubDynamic.Resource(common.GvrPolicy)
+		var policy *unstructured.Unstructured
+		Eventually(
+			func() error {
+				var err error
+				policy, err = policyRsrc.Namespace(namespace).Get(
+					ctx, policyName, metav1.GetOptions{},
+				)
+
+				return err
+			},
+			defaultTimeoutSeconds*2,
+			1,
+		).ShouldNot(HaveOccurred())
+
+		templates, found, err := unstructured.NestedSlice(policy.Object, "spec", "policy-templates")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).Should(BeTrue())
+		Expect(templates).Should(HaveLen(3))
+
+		for _, template := range templates {
+			objSpec, found, err := unstructured.NestedMap(template.(map[string]interface{}), "objectDefinition", "spec")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(found).Should(BeTrue())
+			Expect(objSpec["severity"]).Should(Equal("critical"))
+			objTemplates, found, err := unstructured.NestedSlice(objSpec, "object-templates")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(found).Should(BeTrue())
+			Expect(objTemplates).Should(HaveLen(1))
+			templateObj := objTemplates[0].(map[string]interface{})
+			Expect(templateObj["complianceType"]).Should(Equal("musthave"))
+		}
+
+		By("Checking that the policy was propagated to the local-cluster namespace")
+		Eventually(
+			func() error {
+				_, err := policyRsrc.Namespace("local-cluster").Get(
+					ctx,
+					namespace+"."+policyName,
+					metav1.GetOptions{},
+				)
+
+				return err
+			},
+			defaultTimeoutSeconds*2,
+			1,
+		).ShouldNot(HaveOccurred())
+
+		By("Checking that the configuration policies were created in the local-cluster namespace")
+		configPolicyRsrc := clientHubDynamic.Resource(common.GvrConfigurationPolicy)
+		for _, suffix := range []string{"", "2", "3"} {
+			Eventually(
+				func() error {
+					_, err := configPolicyRsrc.Namespace("local-cluster").Get(
+						ctx, policyName+suffix, metav1.GetOptions{},
+					)
+
+					return err
+				},
+				defaultTimeoutSeconds,
+				1,
+			).ShouldNot(HaveOccurred())
+		}
+
+		By("Confirming that the Helm lookup returned nothing")
+		helmDeploymentPolicy, err := configPolicyRsrc.Namespace("local-cluster").Get(
+			ctx, policyName+"3", metav1.GetOptions{},
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		objTemplates, found, err := unstructured.NestedSlice(helmDeploymentPolicy.Object, "spec", "object-templates")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).Should(BeTrue(), "object-templates should be present in the ConfigurationPolicy")
+		Expect(objTemplates).Should(HaveLen(1), "There should only be one object-template in the ConfigurationPolicy")
+		labelSpyValue, found, err := unstructured.NestedString(
+			objTemplates[0].(map[string]interface{}),
+			"objectDefinition", "spec", "template", "metadata", "labels", "label-spy",
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).Should(BeTrue(), "label 'label-spy' should be present in the ConfigurationPolicy")
+		Expect(labelSpyValue).Should(BeEmpty(), "label-spy should not have content from Helm lookup")
+	})
+})

--- a/test/integration/policy_generator_remote_test.go
+++ b/test/integration/policy_generator_remote_test.go
@@ -29,6 +29,21 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			namespace,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			appSubRsrc, err := clientHubDynamic.Resource(common.GvrSubscription).Namespace(namespace).Get(
+				context.TODO(), "grc-e2e-remote-policy-generator-subscription", metav1.GetOptions{},
+			)
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription should exist.")
+
+			appSubPhase, found, err := unstructured.NestedString(appSubRsrc.Object, "status", "phase")
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription status should be parseable.")
+			g.Expect(found).Should(BeTrue(), "The subscription status should have a phase.")
+			g.Expect(appSubPhase).Should(Equal("Propagated"), "The subscription should propagate successfully.")
+		},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
 	})
 
 	It("Validates the propagated policies", func() {

--- a/test/integration/policy_generator_test.go
+++ b/test/integration/policy_generator_test.go
@@ -29,6 +29,21 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the Policy Generator "+
 			namespace,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			appSubRsrc, err := clientHubDynamic.Resource(common.GvrSubscription).Namespace(namespace).Get(
+				context.TODO(), "grc-e2e-policy-generator-subscription", metav1.GetOptions{},
+			)
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription should exist.")
+
+			appSubPhase, found, err := unstructured.NestedString(appSubRsrc.Object, "status", "phase")
+			g.Expect(err).ShouldNot(HaveOccurred(), "The subscription status should be parseable.")
+			g.Expect(found).Should(BeTrue(), "The subscription status should have a phase.")
+			g.Expect(appSubPhase).Should(Equal("Propagated"), "The subscription should propagate successfully.")
+		},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
 	})
 
 	It("Validates the propagated policies", func() {

--- a/test/resources/policy_generator/helm-kustomization/base/kustomization.yaml
+++ b/test/resources/policy_generator/helm-kustomization/base/kustomization.yaml
@@ -2,4 +2,4 @@ helmCharts:
 - valuesInline:
     enableLookup: true
   name: helm
-  repo: https://github.com/dhaiducek/grc-e2e-policy-generator-test/raw/package-helm/helm/
+  repo: https://github.com/stolostron/grc-e2e-policy-generator-test/raw/main/helm/

--- a/test/resources/policy_generator/subscription-helm.yaml
+++ b/test/resources/policy_generator/subscription-helm.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+spec:
+  clusterSet: global
+---
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: grc-e2e-helm-policy-generator
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - grc-e2e-helm-policy-generator
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: grc-e2e-helm-policy-generator
+spec:
+  type: Git
+  pathname: https://github.com/stolostron/governance-policy-framework.git
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/git-branch: main
+    apps.open-cluster-management.io/git-path: test/resources/policy_generator/helm-kustomization
+    apps.open-cluster-management.io/reconcile-option: merge
+  labels:
+    app: grc-e2e-helm-policy-generator
+  name: grc-e2e-helm-policy-generator-subscription
+spec:
+  channel: grc-e2e-helm-policy-generator/grc-e2e-helm-policy-generator
+  placement:
+    placementRef:
+      kind: Placement
+      name: grc-e2e-helm-policy-generator-placement
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  labels:
+    app: grc-e2e-helm-policy-generator
+  name: grc-e2e-helm-policy-generator-placement
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: local-cluster
+          operator: In
+          values:
+            - "true"


### PR DESCRIPTION
Confirmed that `kustomize` internally uses `helm template`:
https://github.com/kubernetes-sigs/kustomize/blob/91ccf00ac8f787551eb4c5baad486b088ef3737b/api/types/helmchartargs.go#L149

Which doesn't call the Kubernetes API, so security here should be fine, but we have a `lookup` in the chart just to make sure:
```shell
$ helm template --help
Render chart templates locally and display the output.

Any values that would normally be looked up or retrieved in-cluster will be
faked locally. Additionally, none of the server-side testing of chart validity
(e.g. whether an API is supported) is done.
```

ref: https://issues.redhat.com/browse/ACM-9456