### PR TITLE
Add a SVT test for compliance history

### DIFF
--- a/test/common/gvr.go
+++ b/test/common/gvr.go
@@ -127,4 +127,14 @@ var (
 		Version:  "v1beta2",
 		Resource: "managedclustersets",
 	}
+	GvrAddonDeploymentConfig = schema.GroupVersionResource{
+		Group:    "addon.open-cluster-management.io",
+		Version:  "v1alpha1",
+		Resource: "addondeploymentconfigs",
+	}
+	GvrClusterManagementAddOn = schema.GroupVersionResource{
+		Group:    "addon.open-cluster-management.io",
+		Version:  "v1alpha1",
+		Resource: "clustermanagementaddons",
+	}
 )

--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -1,0 +1,279 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package integration
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stolostron/governance-policy-framework/test/common"
+)
+
+// Note that this is set to Serial since the cleanup involves restarting the propagator to clear its cache of database
+// IDs.
+var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", Ordered, Serial, Label("BVT"), func() {
+	var eventsEndpoint string
+	var token string
+	const saName = "compliance-history-user"
+
+	httpClient := http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	BeforeAll(func(ctx context.Context) {
+		By("Setting up Postgres in " + common.OCMNamespace)
+		_, err := common.OcHub(
+			"apply",
+			"-n",
+			common.OCMNamespace,
+			"-f",
+			"../resources/compliance_history/compliance-api-prerequisites.yaml",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating a service account in the default namespace with access to all managed clusters")
+		_, err = common.OcHub("apply", "-f", "../resources/compliance_history/service_account.yaml")
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			By("Getting the service account token")
+			secret, err := common.ClientHub.CoreV1().Secrets("default").Get(ctx, saName, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(secret.Data["token"]).ToNot(BeNil())
+
+			token = string(secret.Data["token"])
+		}, common.DefaultTimeoutSeconds, 1).Should(Succeed())
+
+		var routeHost string
+
+		Eventually(func(g Gomega) {
+			By("Getting the compliance history API route")
+			route, err := common.ClientHubDynamic.Resource(common.GvrRoute).Namespace(common.OCMNamespace).Get(
+				ctx, "governance-history-api", metav1.GetOptions{},
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			routeHost, _, _ = unstructured.NestedString(route.Object, "spec", "host")
+
+			g.Expect(routeHost).ToNot(BeEmpty())
+		}, common.DefaultTimeoutSeconds, 1).Should(Succeed())
+
+		eventsEndpoint = fmt.Sprintf("https://%s/api/v1/compliance-events", routeHost)
+
+		By("Creating the AddOnDeploymentConfig with the complianceHistoryAPIURL variable")
+		addonDeploymentConfig := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "addon.open-cluster-management.io/v1alpha1",
+				"kind":       "AddOnDeploymentConfig",
+				"metadata": map[string]interface{}{
+					"name": "governance-policy-framework",
+				},
+				"spec": map[string]interface{}{
+					"customizedVariables": []interface{}{
+						map[string]interface{}{
+							"name":  "complianceHistoryAPIURL",
+							"value": "https://" + routeHost,
+						},
+					},
+				},
+			},
+		}
+
+		_, err = clientHubDynamic.Resource(common.GvrAddonDeploymentConfig).Namespace(common.OCMNamespace).Create(
+			ctx, &addonDeploymentConfig, metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Setting the governance-policy-framework ClusterManagementAddOn to use the AddOnDeploymentConfig")
+		cma, err := clientHubDynamic.Resource(common.GvrClusterManagementAddOn).Get(
+			ctx, "governance-policy-framework", metav1.GetOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		supportedConfigs := []interface{}{
+			map[string]interface{}{
+				"group":    "addon.open-cluster-management.io",
+				"resource": "addondeploymentconfigs",
+				"defaultConfig": map[string]interface{}{
+					"name":      "governance-policy-framework",
+					"namespace": common.OCMNamespace,
+				},
+			},
+		}
+
+		err = unstructured.SetNestedField(cma.Object, supportedConfigs, "spec", "supportedConfigs")
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = clientHubDynamic.Resource(common.GvrClusterManagementAddOn).Update(ctx, cma, metav1.UpdateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the compliance endpoint is up")
+		Eventually(func(g Gomega) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, eventsEndpoint, nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			resp, err := httpClient.Do(req)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(resp.StatusCode).To(
+				Equal(http.StatusOK), "expected the compliance API to return the 200 status code",
+			)
+		}, common.DefaultTimeoutSeconds*2, 1).Should(Succeed())
+	})
+
+	AfterAll(func(ctx context.Context) {
+		By("Deleting the policy")
+		_, err := common.OcHub(
+			"delete",
+			"-f",
+			"../resources/compliance_history/policy.yaml",
+			"--ignore-not-found",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deleting Postgres")
+		_, err = common.OcHub(
+			"delete",
+			"-n",
+			common.OCMNamespace,
+			"-f",
+			"../resources/compliance_history/compliance-api-prerequisites.yaml",
+			"--ignore-not-found",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deleting the service account in the default namespace")
+		_, err = common.OcHub(
+			"delete", "-f", "../resources/compliance_history/service_account.yaml", "--ignore-not-found",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deleting the AddOnDeploymentConfig")
+		err = clientHubDynamic.Resource(common.GvrAddonDeploymentConfig).Namespace(common.OCMNamespace).Delete(
+			ctx, "governance-policy-framework", metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Restarting the Propagator to clear its compliance database ID cache")
+		_, err = common.OcHub(
+			"-n", common.OCMNamespace, "rollout", "restart", "deployment/grc-policy-propagator",
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Creates a policy with a compliant and noncompliant configuration policy", func(ctx context.Context) {
+		const policyName = "compliance-history-test"
+		const policyNS = "open-cluster-management-global-set"
+
+		now := time.Now().Add(-1 * time.Second).Format(time.RFC3339)
+
+		By("Creating the policy")
+		_, err := common.OcHub(
+			"apply",
+			"-f",
+			"../resources/compliance_history/policy.yaml",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		var parentPolicy *unstructured.Unstructured
+		var clusters []string
+
+		Eventually(func(g Gomega) {
+			By("Checking to see if the policy is noncompliant on all clusters")
+			var err error
+			clusters = []string{}
+
+			parentPolicy, err = clientHubDynamic.Resource(common.GvrPolicy).Namespace(policyNS).Get(
+				ctx, policyName, metav1.GetOptions{},
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			perClusterStatus, _, _ := unstructured.NestedSlice(parentPolicy.Object, "status", "status")
+			g.Expect(perClusterStatus).ToNot(BeEmpty(), "no cluster status was available on the parent policy")
+
+			for _, clusterStatus := range perClusterStatus {
+				clusterStatus, ok := clusterStatus.(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "the cluster status was not the right type")
+
+				g.Expect(clusterStatus["compliant"]).To(Equal("NonCompliant"))
+				g.Expect(clusterStatus["clustername"]).ToNot(BeEmpty())
+				clusters = append(clusters, clusterStatus["clustername"].(string))
+			}
+		}, common.DefaultTimeoutSeconds, 1).Should(Succeed())
+
+		expectedEvents := len(clusters) * 2
+
+		By(fmt.Sprintf("Verifying that there are %d compliance events for the parent policy", expectedEvents))
+		Eventually(func(g Gomega) {
+			for _, cluster := range clusters {
+				// event.timestamp_after is used to filter compliance events from previous runs if the test
+				// is run multiple times. This won't be needed after https://issues.redhat.com/browse/ACM-9314 is
+				// addressed.
+				url := fmt.Sprintf(
+					"%s?cluster.name=%s&parent_policy.name=%s&event.timestamp_after=%s",
+					eventsEndpoint,
+					cluster,
+					policyName,
+					now,
+				)
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				req.Header.Set("Authorization", "Bearer "+token)
+
+				resp, err := httpClient.Do(req)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				defer resp.Body.Close()
+
+				g.Expect(resp.StatusCode).To(
+					Equal(http.StatusOK), "expected the compliance API to return the 200 status code",
+				)
+
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				respJSON := map[string]any{}
+
+				err = json.Unmarshal(body, &respJSON)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(respJSON["data"]).To(
+					HaveLen(2), fmt.Sprintf("expected cluster %s to have two events", cluster),
+				)
+
+				events := respJSON["data"].([]interface{})
+				event1 := events[0].(map[string]interface{})
+				event2 := events[1].(map[string]interface{})
+
+				if event1["policy"].(map[string]interface{})["name"].(string) == "default-namespace-must-exist" {
+					g.Expect(event1["event"].(map[string]interface{})["compliance"]).To(Equal("Compliant"))
+					g.Expect(event2["event"].(map[string]interface{})["compliance"]).To(Equal("NonCompliant"))
+				} else {
+					g.Expect(event1["event"].(map[string]interface{})["compliance"]).To(Equal("NonCompliant"))
+					g.Expect(event2["event"].(map[string]interface{})["compliance"]).To(Equal("Compliant"))
+				}
+
+			}
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+	})
+})

--- a/test/resources/compliance_history/compliance-api-prerequisites.yaml
+++ b/test/resources/compliance_history/compliance-api-prerequisites.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: compliance-history-postgres
+  labels:
+    app: compliance-history-postgres
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: compliance-history-postgres-cert
+spec:
+  selector:
+    app: compliance-history-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: compliance-history-postgres
+  name: compliance-history-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: compliance-history-postgres
+  template:
+    metadata:
+      labels:
+        app: compliance-history-postgres
+    spec:
+      containers:
+      - command:
+        - run-postgresql
+        - -c
+        - ssl=on
+        - -c
+        - ssl_cert_file=/etc/ssl/certs/tls.crt
+        - -c
+        - ssl_key_file=/etc/ssl/certs/tls.key
+        - -c
+        - ssl_ca_file=/etc/ssl/certs/tls.crt
+        - -c
+        - log_statement=all
+        - -c
+        - log_destination=stderr
+        env:
+        - name: POSTGRESQL_DATABASE
+          value: grc
+        - name: POSTGRESQL_USER
+          value: grc
+        - name: POSTGRESQL_PASSWORD
+          value: grc
+        image: registry.redhat.io/rhel8/postgresql-13:latest
+        imagePullPolicy: Always
+        name: compliance-history-postgres
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 60m
+            memory: 512Mi
+          requests:
+            cpu: 30m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsNonRoot: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: postgres-ssl-certs
+          readOnly: true
+        - mountPath: /var/lib/pgsql/data
+          name: postgres-db
+          subPath: data
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: postgres-ssl-certs
+        secret:
+          defaultMode: 288
+          secretName: compliance-history-postgres-cert
+      - emptyDir:
+          sizeLimit: 250Mi
+        name: postgres-db
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: governance-policy-database
+stringData:
+  connectionURL: postgres://grc:grc@compliance-history-postgres/grc?sslmode=require

--- a/test/resources/compliance_history/policy.yaml
+++ b/test/resources/compliance_history/policy.yaml
@@ -1,0 +1,63 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: compliance-history-test
+  namespace: open-cluster-management-global-set
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: default-namespace-must-exist
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: default
+          remediationAction: inform
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: does-not-exist-namespace-must-exist
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: does-not-exist
+          remediationAction: inform
+          severity: low
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: compliance-history-test
+  namespace: open-cluster-management-global-set
+spec: {}
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: compliance-history-test
+  namespace: open-cluster-management-global-set
+placementRef:
+  name: compliance-history-test
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: compliance-history-test
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/test/resources/compliance_history/service_account.yaml
+++ b/test/resources/compliance_history/service_account.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: compliance-history-user
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: compliance-history-user
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: compliance-history-user
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: compliance-history-user
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  resourceNames:
+  - "*"
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compliance-history-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compliance-history-user
+subjects:
+- kind: ServiceAccount
+  name: compliance-history-user
+  namespace: default


### PR DESCRIPTION
The test creates a policy that applies to all clusters. It has one configuration policy that is always compliant and the other configuration policy is always noncompliant. The test verifies that these compliance events are present on the compliance history API for every managed cluster.

Relates:
https://issues.redhat.com/browse/ACM-10033