### PR TITLE
Set Go version for Integration Test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Checkout Policy Framework
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     - name: Cluster setup
       run: |
         echo "::group::Set up prerequisites"

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -80,6 +80,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: framework/go.mod
+        cache-dependency-path: framework/go.sum
 
     - name: Verify modules
       if: ${{ github.event.repository.name == 'governance-policy-framework' }}


### PR DESCRIPTION
With the updated propagator, Go v1.21 is a requirement, but Go v1.20 is currently the default in GitHub Actions.