### PR TITLE
Fix Gatekeeper operator cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 /kubeconfig_*
-.vscode/launch.json
+.vscode/
 test/e2e/debug.test
 /results
 /test-output
 test/policy-collection/policy-collection.test
 test/policy-collection/debug.test
+test/integration/integration.test
 .DS_Store
 
 .go

--- a/build/clean-up-cluster.sh
+++ b/build/clean-up-cluster.sh
@@ -29,11 +29,12 @@ function delete_all_and_wait() {
 
 function hub() {
     echo "Hub: clean up"
+    oc delete policies.policy.open-cluster-management.io --all-namespaces --all --ignore-not-found
+    oc delete placementbindings.policy.open-cluster-management.io  --all-namespaces --all --ignore-not-found
+    oc delete placementrules.apps.open-cluster-management.io --all-namespaces --all --ignore-not-found
+    # Don't clean up in all namespaces because the global-set placement shouldn't be deleted
     for ns in default policy-test e2e-rbac-test-1 e2e-rbac-test-2
         do
-            oc delete policies.policy.open-cluster-management.io -n $ns --all --ignore-not-found
-            oc delete placementbindings.policy.open-cluster-management.io  -n $ns --all --ignore-not-found
-            oc delete placementrules.apps.open-cluster-management.io -n $ns --all --ignore-not-found
             oc delete placements.cluster.open-cluster-management.io -n $ns --all --ignore-not-found
         done
     oc delete ns -l e2e=true --ignore-not-found

--- a/test/resources/compliance_history/policy-uninstall-gk.yaml
+++ b/test/resources/compliance_history/policy-uninstall-gk.yaml
@@ -10,16 +10,47 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-api-uninstall-gk
+          name: compliance-api-uninstall-gk-csv
         spec:
           object-templates-raw: |
-            {{- $csvName := (lookup "operators.coreos.com/v1alpha1" "Subscription" "openshift-operators" "gatekeeper-operator-product").status.installedCSV -}}
+
+            {{ range $ns := (lookup "v1" "Namespace" "" "").items }}
+            {{ range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion"  "" "").items }}
+            {{ $csvName := $csv.metadata.name }}
+            {{ if hasPrefix "gatekeeper-operator-product." $csvName }}
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  name: {{ $csvName }}
+                  namespace: {{ $ns.metadata.name }}
+            {{ end }}
+            {{ end }}
+            {{ end }}
+          remediationAction: enforce
+          severity: critical
+    - extraDependencies:
+      - apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        name: compliance-api-uninstall-gk-csv
+        compliance: Compliant
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-api-uninstall-gk-sub
+        spec:
+          object-templates-raw: |
+
+            {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gatekeepers.operator.gatekeeper.sh").metadata.name) "" }}
             - complianceType: mustnothave
               objectDefinition:
                 apiVersion: operator.gatekeeper.sh/v1alpha1
                 kind: Gatekeeper
                 metadata:
                   name: gatekeeper
+            {{ end }}
             - complianceType: mustnothave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
@@ -27,15 +58,6 @@ spec:
                 metadata:
                   name: gatekeeper-operator-product
                   namespace: openshift-operators
-            {{- if $csvName }}
-            - complianceType: mustnothave
-              objectDefinition:
-                apiVersion: operators.coreos.com/v1alpha1
-                kind: ClusterServiceVersion
-                metadata:
-                  name: {{ $csvName }}
-                  namespace: openshift-operators
-            {{- end }}
           remediationAction: enforce
           severity: critical
 ---


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-10556

There were some competing causes to the flakiness for these tests:
- We ran into an unrecoverable OLM caching bug outlined in https://access.redhat.com/solutions/6991414, solved by restarting the OLM pods
- The compliance history Gatekeeper cleanup Policy was not getting deleted, causing it to linger and continuously clean up when the Gatekeeper test would run (possibly causing the unrecoverable state?)
- Cleanup commands in Gatekeeper were also getting skipped because not all resources had been deployed and it didn't tolerate that.

The cleanup script was also only cleaning up in certain namespaces when the Gatekeeper cleanup policy had been deployed to the global-set namespace. This updates the commands to clean up policies aggressively across all namespace.