### PR TITLE
Fix the compliance history configuration policy name

### DIFF
--- a/test/resources/compliance_history/policy-gk-prereq2.yaml
+++ b/test/resources/compliance_history/policy-gk-prereq2.yaml
@@ -15,7 +15,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-api-configure-gk
+          name: compliance-api-configure-namespace-configmap
         spec:
           pruneObjectBehavior: DeleteAll
           object-templates:


### PR DESCRIPTION
The ConfigurationPolicy names must match in `policy-gk-prereq.yaml` and `policy-gk-prereq2.yaml`.