### PR TITLE
Increase verify policy on all clusters func timeout

### DIFF
--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -610,7 +610,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking to see if the cert policy is compliant on the managed clusters")
-		clusters := verifyPolicyOnAllClusters(ctx, policyNS, policyName, "Compliant", defaultTimeoutSeconds)
+		clusters := verifyPolicyOnAllClusters(ctx, policyNS, policyName, "Compliant", defaultTimeoutSeconds*2)
 
 		By("Create wrong tls secret")
 		key, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
Increase verifyPolicyOnAllClusters timeout from 30 secs to 60 secs as we discussed

Ref: https://redhat-internal.slack.com/archives/CUS1VB8P3/p1712154840798339