### PR TITLE
Remove diff from output

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+: "${GITHUB_USER:?GITHUB_USER must be set}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
 
 CHECK_RELEASES="$(cat ${DIR}/../CURRENT_VERSION; echo; cat ${DIR}/../CURRENT_SUPPORTED_VERSIONS)"
 COMPONENT_ORG=stolostron


### PR DESCRIPTION
The diff will still be in the workflow logs and summary, but it's too long for things like Slack messages.