### PR TITLE
Manual cherry pick 2.10

### DIFF
--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -188,7 +188,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			g.Expect(resp.StatusCode).To(
 				Equal(http.StatusOK), "expected the compliance API to return the 200 status code",
 			)
-		}, common.DefaultTimeoutSeconds*2, 1).Should(Succeed())
+		}, common.DefaultTimeoutSeconds*4, 1).Should(Succeed())
 	})
 
 	AfterAll(func(ctx context.Context) {

--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -576,6 +576,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 
 	It("Creates a policy with a compliant and non-compliant cert policy", func(ctx context.Context) {
 		const policyName = "cert-policy"
+		const prereqPolicyName = "ch-cert-prereq-policy"
 		const certNs = "ch-cert-policy-test-ns"
 		const certPath = "../resources/compliance_history/cert-policy.yaml"
 		const certSecret = "cert-secret"
@@ -613,6 +614,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			"-n", policyNS,
 		)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying that the policy has created the namespace")
+		verifyPolicyOnAllClusters(ctx, policyNS, prereqPolicyName, "Compliant", defaultTimeoutSeconds)
 
 		By("Creating the policy")
 		_, err = common.OcHub(
@@ -691,6 +695,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 		const opPolicyPath = "../resources/compliance_history/operator-policy-invalid.yaml"
 		const policyName = "op-compliance-api"
 		const nsPolicyPath = "../resources/compliance_history/operator-prereq.yaml"
+		const prereqPolicyName = "ch-operator-prereq-policy"
 
 		DeferCleanup(func(ctx context.Context) {
 			By("Deleting the operator policy")
@@ -723,6 +728,9 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			"-n", policyNS,
 		)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying that the policy has created the namespace")
+		verifyPolicyOnAllClusters(ctx, policyNS, prereqPolicyName, "Compliant", defaultTimeoutSeconds)
 
 		By("Creating the Policy")
 		_, err = common.OcHub(

--- a/test/resources/compliance_history/cert-prereq.yaml
+++ b/test/resources/compliance_history/cert-prereq.yaml
@@ -26,6 +26,21 @@ spec:
               metadata:
                 name: ch-cert-policy-test-ns
           severity: critical
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: ch-secret-prereq-configpolicy
+        spec:
+          pruneObjectBehavior: DeleteAll
+          object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: ch-cert-secret
+                namespace: ch-cert-policy-test-ns
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement


### PR DESCRIPTION
The auto cherry-pick has failed. 
- Change the adding cert secret from command to policy
- Increase timeout for compliance API to be ready
- Wait for namespace in history tests