### PR TITLE
Add some debug messages and address some flaky tests

### DIFF
--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -188,6 +188,9 @@ func GetHistoryMessages(policyName string, templateIdx int) ([]interface{}, bool
 	return history, found, err
 }
 
+// GetOpPolicyCompMsg returns a function (so that it can be used in an Eventually)
+// that returns the current Compliant condition message on the specified OperatorPolicy.
+// It will return an empty string if the OperatorPolicy or condition could not be found.
 func GetOpPolicyCompMsg(policyName string) func() string {
 	return func() string {
 		unstructOpPol := utils.GetWithTimeout(
@@ -362,4 +365,18 @@ func setRemediationAction(
 			g.ExpectWithOffset(1, action).To(Equal(remediationAction))
 		}, DefaultTimeoutSeconds, 1).Should(Succeed())
 	}
+}
+
+// RegisterDebugMessage returns a pointer to a string which this function will register to be
+// printed in the ginkgo logs only if the test fails.
+func RegisterDebugMessage() *string {
+	msg := new(string)
+
+	DeferCleanup(func() {
+		if CurrentSpecReport().Failed() {
+			GinkgoWriter.Println(*msg)
+		}
+	})
+
+	return msg
 }

--- a/test/integration/policy_install_operator_test.go
+++ b/test/integration/policy_install_operator_test.go
@@ -144,12 +144,15 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 				).Should(MatchRegexp("Compliant.*the OperatorGroup matches what is required by the policy.*" +
 					"the Subscription matches what is required by the policy.*"))
 
+				msg := common.RegisterDebugMessage()
+
 				By("Checking if the status of the root policy is compliant")
-				Eventually(
-					common.GetComplianceState(policyNamePrefix+noGroupSuffix),
-					defaultTimeoutSeconds*4,
-					1,
-				).Should(Equal(policiesv1.Compliant))
+				Eventually(func(g Gomega) interface{} {
+					*msg = "Current compliance condition of OperatorPolicy: " +
+						common.GetOpPolicyCompMsg("operator-policy"+noGroupSuffix)()
+
+					return common.GetComplianceState(policyNamePrefix + noGroupSuffix)(g)
+				}, defaultTimeoutSeconds*4, 1).Should(Equal(policiesv1.Compliant))
 			})
 
 			It("Should verify OperatorGroup details", func() {
@@ -337,12 +340,15 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 				).Should(MatchRegexp("NonCompliant.*the OperatorGroup required by the policy was not found.*" +
 					"the Subscription required by the policy was not found.*"))
 
+				debugMsg := common.RegisterDebugMessage()
+
 				By("Checking if the status of the root policy is NonCompliant")
-				Eventually(
-					common.GetComplianceState(policyNamePrefix+withGroupSuffix),
-					defaultTimeoutSeconds*2,
-					1,
-				).Should(Equal(policiesv1.NonCompliant))
+				Eventually(func(g Gomega) interface{} {
+					*debugMsg = "Current compliance condition of OperatorPolicy: " +
+						common.GetOpPolicyCompMsg("operator-policy"+withGroupSuffix)()
+
+					return common.GetComplianceState(policyNamePrefix + withGroupSuffix)(g)
+				}, defaultTimeoutSeconds*2, 1).Should(Equal(policiesv1.NonCompliant))
 			})
 
 			It("Should enforce the policy on the hub", func() {
@@ -355,12 +361,15 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 				).Should(MatchRegexp("Compliant.*the OperatorGroup matches what is required by the policy.*" +
 					"the Subscription matches what is required by the policy.*"))
 
+				debugMsg := common.RegisterDebugMessage()
+
 				By("Checking if the status of the root policy is compliant")
-				Eventually(
-					common.GetComplianceState(policyNamePrefix+withGroupSuffix),
-					defaultTimeoutSeconds*2,
-					1,
-				).Should(Equal(policiesv1.Compliant))
+				Eventually(func(g Gomega) interface{} {
+					*debugMsg = "Current compliance condition of OperatorPolicy: " +
+						common.GetOpPolicyCompMsg("operator-policy"+withGroupSuffix)()
+
+					return common.GetComplianceState(policyNamePrefix + withGroupSuffix)(g)
+				}, defaultTimeoutSeconds*2, 1).Should(Equal(policiesv1.Compliant))
 			})
 
 			It("Should verify OperatorGroup details", func() {


### PR DESCRIPTION
The new `RegisterDebugMessage` is based off of a pattern that is working well in the config-policy-controller tests in order to only print certain debug information when the test fails. This is especially useful in `Eventually` assertions.

This updates several tests to use this new function which will hopefully help in debugging some inconsistent tests.

Refs:
 - https://github.com/stolostron/backlog/issues/27556
 - https://github.com/stolostron/backlog/issues/27558

2nd Commit:

Combine operator tests for sub, csv, and deploy

This test was running inconsistently because depending on how quickly OLM finds and applies the possible upgrade for the operator, the test was sometimes looking for an older CSV.

Refs:
 - https://github.com/stolostron/backlog/issues/27561
 - https://github.com/stolostron/backlog/issues/27557
 - https://github.com/stolostron/backlog/issues/27556