### PR TITLE
Remove startingCSV from the test operator policies

### DIFF
--- a/test/integration/policy_install_operator_test.go
+++ b/test/integration/policy_install_operator_test.go
@@ -201,7 +201,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 
 			It("Should verify Subscription, CSV, and Deployment details", func() {
 				Eventually(func(g Gomega) {
-					// Because of possible upgrades, lookup the CSV name every time
+					// Because the version is not pinned, get the CSV name every time
 					sub := utils.GetWithTimeout(
 						clientManagedDynamic,
 						common.GvrSubscriptionOLM,
@@ -380,7 +380,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 
 			It("Should verify Subscription, CSV, and Deployment details", func() {
 				Eventually(func(g Gomega) {
-					// Because of possible upgrades, lookup the CSV name every time
+					// Because the version is not pinned, get the CSV name every time
 					sub := utils.GetWithTimeout(
 						clientManagedDynamic,
 						common.GvrSubscriptionOLM,

--- a/test/resources/operator_policy/test-op-err-correct.yaml
+++ b/test/resources/operator_policy/test-op-err-correct.yaml
@@ -25,7 +25,6 @@ spec:
             installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
-            startingCSV: quay-operator.v3.8.1
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/operator_policy/test-op-err-initial.yaml
+++ b/test/resources/operator_policy/test-op-err-initial.yaml
@@ -25,7 +25,6 @@ spec:
             installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
-            startingCSV: quay-operator.v3.8.1
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/operator_policy_no_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_no_group.yaml
@@ -24,7 +24,6 @@ spec:
             installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
-            startingCSV: quay-operator.v3.8.1
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/operator_policy_with_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_with_group.yaml
@@ -29,7 +29,6 @@ spec:
             installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
-            startingCSV: quay-operator.v3.8.1
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
Since the tests don't test upgrades, it's more reliable to have OLM pick the latest on the channel rather than have it potentially upgrade.

Relates:
https://github.com/stolostron/backlog/issues/27575