### PR TITLE
Use the matching release branch on the policy-collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ e2e-debug-dump:
 
 .PHONY: integration-test
 integration-test: e2e-dependencies
-	$(GINKGO) -v $(TEST_ARGS) test/integration -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(MANAGED_CLUSTER_NAMESPACE) -patch_decisions=false
+	$(GINKGO) -v $(TEST_ARGS) test/integration -- -cluster_namespace=$(MANAGED_CLUSTER_NAMESPACE) -k8s_client=$(K8SCLIENT) -is_hosted=$(IS_HOSTED) -cluster_namespace_on_hub=$(MANAGED_CLUSTER_NAMESPACE) -patch_decisions=false -policy_collection_branch=$(RELEASE_BRANCH)
 
 #hosted
 ADDON_CONTROLLER = $(PWD)/.go/governance-policy-addon-controller

--- a/build/run-e2e-tests-policy-framework-prow.sh
+++ b/build/run-e2e-tests-policy-framework-prow.sh
@@ -61,7 +61,7 @@ fi
 echo "===== E2E Test ====="
 echo "* Launching grc policy framework test"
 # Run test suite with reporting
-CGO_ENABLED=0 ${DIR}/../bin/ginkgo -v --no-color --fail-fast ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME || EXIT_CODE=$?
+CGO_ENABLED=0 ${DIR}/../bin/ginkgo -v --no-color --fail-fast ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -policy_collection_branch=$TARGET_BRANCH || EXIT_CODE=$?
 
 # Remove Ginkgo phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then

--- a/build/run-test-image.sh
+++ b/build/run-test-image.sh
@@ -15,6 +15,13 @@ else
   echo "* Using GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER}"
 fi
 
+if [[ -z ${POLICY_COLLECTION_BRANCH} ]]; then
+  echo "* No POLICY_COLLECTION_BRANCH set, using main for the policy-collection branch"
+  POLICY_COLLECTION_BRANCH="main"
+else
+  echo "* Using POLICY_COLLECTION_BRANCH=${POLICY_COLLECTION_BRANCH}"
+fi
+
 if [[ -z ${OCM_NAMESPACE} ]]; then
   echo "* OCM_NAMESPACE not set, using open-cluster-management"
   OCM_NAMESPACE="open-cluster-management"
@@ -30,7 +37,7 @@ else
 fi
 
 # Run test suite with reporting
-CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE -ocm_addon_namespace=$OCM_ADDON_NAMESPACE -patch_decisions=false || EXIT_CODE=$?
+CGO_ENABLED=0 ./bin/ginkgo -v ${GINKGO_FAIL_FAST} ${GINKGO_LABEL_FILTER} --junit-report=integration.xml --output-dir=test-output test/integration -- -cluster_namespace=$MANAGED_CLUSTER_NAME -ocm_namespace=$OCM_NAMESPACE -ocm_addon_namespace=$OCM_ADDON_NAMESPACE -patch_decisions=false -policy_collection_branch=$POLICY_COLLECTION_BRANCH || EXIT_CODE=$?
 
 # Remove Gingko phases from report to prevent corrupting bracketed metadata
 if [ -f test-output/integration.xml ]; then

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -33,6 +33,7 @@ var (
 	UserNamespace          string
 	ClusterNamespace       string
 	ClusterNamespaceOnHub  string
+	PolicyCollectionBranch string
 	OCMNamespace           string
 	OCMAddOnNamespace      string
 	DefaultTimeoutSeconds  int
@@ -77,6 +78,9 @@ func InitFlags(flagset *flag.FlagSet) {
 		"ocm_addon_namespace",
 		"open-cluster-management-agent-addon",
 		"ns of ocm addon installations",
+	)
+	flagset.StringVar(
+		&PolicyCollectionBranch, "policy_collection_branch", "main", "the branch of the policy-collection repo",
 	)
 	flagset.IntVar(&DefaultTimeoutSeconds, "timeout_seconds", 30, "Timeout seconds for assertion")
 	flagset.BoolVar(

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -20,15 +21,15 @@ import (
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
 
-const (
-	policyCollectBaseURL      = "https://raw.githubusercontent.com/stolostron/policy-collection/main/"
-	policyCollectCommunityURL = policyCollectBaseURL + "community/"
-	policyCollectStableURL    = policyCollectBaseURL + "stable/"
-	policyCollectACURL        = policyCollectStableURL + "AC-Access-Control/"
-	policyCollectCAURL        = policyCollectStableURL + "CA-Security-Assessment-and-Authorization/"
-	policyCollectCMURL        = policyCollectStableURL + "CM-Configuration-Management/"
-	policyCollectSCURL        = policyCollectStableURL + "SC-System-and-Communications-Protection/"
-	policyCollectSIURL        = policyCollectStableURL + "SI-System-and-Information-Integrity/"
+var (
+	policyCollectBaseURL      string
+	policyCollectCommunityURL string
+	policyCollectStableURL    string
+	policyCollectACURL        string
+	policyCollectCAURL        string
+	policyCollectCMURL        string
+	policyCollectSCURL        string
+	policyCollectSIURL        string
 )
 
 var (
@@ -50,6 +51,17 @@ var (
 )
 
 func TestIntegration(t *testing.T) {
+	policyCollectBaseURL = fmt.Sprintf(
+		"https://raw.githubusercontent.com/stolostron/policy-collection/%s/", common.PolicyCollectionBranch,
+	)
+	policyCollectCommunityURL = policyCollectBaseURL + "community/"
+	policyCollectStableURL = policyCollectBaseURL + "stable/"
+	policyCollectACURL = policyCollectStableURL + "AC-Access-Control/"
+	policyCollectCAURL = policyCollectStableURL + "CA-Security-Assessment-and-Authorization/"
+	policyCollectCMURL = policyCollectStableURL + "CM-Configuration-Management/"
+	policyCollectSCURL = policyCollectStableURL + "SC-System-and-Communications-Protection/"
+	policyCollectSIURL = policyCollectStableURL + "SI-System-and-Information-Integrity/"
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "GRC framework integration test suite")
 }

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -32,10 +32,10 @@ var _ = Describe(
 	func() {
 		const (
 			policyCertificateName   = "policy-certificate"
-			policyCertificateURL    = policyCollectSCURL + policyCertificateName + ".yaml"
 			expiredCertSecretName   = "expired-cert"
 			policyCertificateNSName = "policy-certificate"
 		)
+		policyCertificateURL := policyCollectSCURL + policyCertificateName + ".yaml"
 
 		It("stable/"+policyCertificateName+" should be created on the Hub", func() {
 			By("Creating the policy on the Hub")

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -213,12 +213,15 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 
 var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 	"Test compliance operator and scan", Ordered, Label("policy-collection", "stable"), func() {
+	var (
+		compPolicyURL        = policyCollectCAURL + "policy-compliance-operator-install.yaml"
+		compE8scanPolicyURL  = policyCollectCMURL + "policy-compliance-operator-e8-scan.yaml"
+		compCISscanPolicyURL = policyCollectCMURL + "policy-compliance-operator-cis-scan.yaml"
+	)
+
 	const (
-		compPolicyURL         = policyCollectCAURL + "policy-compliance-operator-install.yaml"
 		compPolicyName        = "policy-comp-operator"
-		compE8scanPolicyURL   = policyCollectCMURL + "policy-compliance-operator-e8-scan.yaml"
 		compE8ScanPolicyName  = "policy-e8-scan"
-		compCISscanPolicyURL  = policyCollectCMURL + "policy-compliance-operator-cis-scan.yaml"
 		compCISScanPolicyName = "policy-cis-scan"
 	)
 

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -24,10 +24,10 @@ var _ = Describe(
 	func() {
 		const (
 			policyEtcdEncryptionName = "policy-etcdencryption"
-			policyEtcdEncryptionURL  = policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
 			apiSeverName             = "cluster"
 			configPolicyName         = "enable-etcd-encryption"
 		)
+		policyEtcdEncryptionURL := policyCollectSCURL + policyEtcdEncryptionName + ".yaml"
 
 		It("stable/"+policyEtcdEncryptionName+" should be created on the Hub", func() {
 			By("Creating the policy on the Hub")

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -20,8 +20,9 @@ import (
 )
 
 var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "BVT"), func() {
-	const gatekeeperPolicyURL = policyCollectStableURL +
+	gatekeeperPolicyURL := policyCollectStableURL +
 		"CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml"
+
 	const gatekeeperPolicyName = "policy-gatekeeper-operator"
 
 	Describe("GRC: [P1][Sev1][policy-grc] Test installing gatekeeper operator", func() {

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	"the policy-imagemanifestvuln policy", Ordered, Label("policy-collection", "stable"), func() {
-	const policyIMVURL = policyCollectSIURL + "policy-imagemanifestvuln.yaml"
+	policyIMVURL := policyCollectSIURL + "policy-imagemanifestvuln.yaml"
 	const policyIMVName = "policy-imagemanifestvuln"
 	const subName = "container-security-operator"
 	const operatorNS = "openshift-operators"

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -24,10 +24,10 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 	Ordered, Label("policy-collection", "stable"), func() {
 		const (
 			policyLimitMemoryName   = "policy-limitmemory"
-			policyLimitMemoryURL    = policyCollectSCURL + policyLimitMemoryName + ".yaml"
 			policyLimitMemoryNSName = "policy-limitmemory"
 			limitRangeName          = "mem-limit-range"
 		)
+		policyLimitMemoryURL := policyCollectSCURL + policyLimitMemoryName + ".yaml"
 
 		It("stable/"+policyLimitMemoryName+" should be created on the Hub", func() {
 			By("Creating the policy on the Hub")

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -21,10 +21,8 @@ import (
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 	Ordered, Label("policy-collection", "stable"), func() {
-		const (
-			policyNamespaceName = "policy-namespace"
-			policyNamespaceURL  = policyCollectCMURL + policyNamespaceName + ".yaml"
-		)
+		const policyNamespaceName = "policy-namespace"
+		policyNamespaceURL := policyCollectCMURL + policyNamespaceName + ".yaml"
 
 		It("stable/"+policyNamespaceName+" should be created on the Hub", func() {
 			By("Creating policy on hub")

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -24,10 +24,10 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 	Ordered, Label("policy-collection", "stable"), func() {
 		const (
 			policyPodName   = "policy-pod"
-			policyPodURL    = policyCollectCMURL + policyPodName + ".yaml"
 			policyPodNSName = "policy-pod"
 			podName         = "sample-nginx-pod"
 		)
+		policyPodURL := policyCollectCMURL + policyPodName + ".yaml"
 
 		It("stable/"+policyPodName+" should be created on the Hub", func() {
 			By("Creating the policy on the Hub")

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -21,9 +21,9 @@ import (
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 	Ordered, Label("policy-collection", "stable"), func() {
+		rootPolicyURL := policyCollectSCURL + "policy-psp.yaml"
 		const (
 			rootPolicyName = "policy-podsecuritypolicy"
-			rootPolicyURL  = policyCollectSCURL + "policy-psp.yaml"
 			pspName        = "sample-restricted-psp"
 		)
 

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -24,10 +24,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 	Ordered, Label("policy-collection", "stable"), func() {
 		const (
 			policyRoleName   = "policy-role"
-			policyRoleURL    = policyCollectACURL + policyRoleName + ".yaml"
 			policyRoleNSName = policyRoleName + "ns"
 			roleName         = "sample-role"
 		)
+		policyRoleURL := policyCollectACURL + policyRoleName + ".yaml"
+
 		It("stable/"+policyRoleName+" should be created on the Hub", func() {
 			By("Creating policy on hub")
 			_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -24,10 +24,11 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 	Ordered, Label("policy-collection", "stable"), func() {
 		const (
 			policyRoleBindingName   = "policy-rolebinding"
-			policyRoleBindingURL    = policyCollectACURL + policyRoleBindingName + ".yaml"
 			policyRoleBindingNSName = policyRoleBindingName + "ns"
 			roleBindingName         = "sample-rolebinding"
 		)
+		policyRoleBindingURL := policyCollectACURL + policyRoleBindingName + ".yaml"
+
 		It("stable/"+policyRoleBindingName+" should be created on the Hub", func() {
 			By("Creating policy on hub")
 			_, err := utils.KubectlWithOutput(

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -18,13 +18,12 @@ import (
 
 var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 	Ordered, Label("policy-collection", "stable"), func() {
+		rootPolicyURL := policyCollectSCURL + "policy-scc.yaml"
 		const (
 			rootPolicyName = "policy-securitycontextconstraints"
-			rootPolicyURL  = policyCollectSCURL + "policy-scc.yaml"
 			targetName     = "restricted"
 			targetKind     = "scc"
 		)
-
 		targetGVR := common.GvrSCC
 
 		It("stable/"+rootPolicyName+" should be created on the Hub", func() {

--- a/test/integration/policy_zts_cmc_test.go
+++ b/test/integration/policy_zts_cmc_test.go
@@ -21,10 +21,10 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 	"the zts-cmc policy", Ordered, Label("policy-collection", "stable"), func() {
 	const (
 		policyName     = "policy-zts-cmc"
-		policyURL      = policyCollectCMURL + policyName + ".yaml"
 		deploymentNS   = "default"
 		deploymentName = "zts-cmc-app-deploy"
 	)
+	policyURL := policyCollectCMURL + policyName + ".yaml"
 
 	It("stable/"+policyName+" should be created on the Hub", func() {
 		By("Creating the policy on the Hub")


### PR DESCRIPTION
This will allow the IAM policy tests to still work on 2.10 and earlier.

Relates:
https://issues.redhat.com/browse/ACM-10859
https://github.com/stolostron/canary-scripts/pull/297
https://github.com/stolostron/governance-policy-framework/pull/796