### PR TITLE
Fix Slack report filter

### DIFF
--- a/build/periodic-slack-report.sh
+++ b/build/periodic-slack-report.sh
@@ -56,13 +56,13 @@ for prefix in "${prefixs[@]}"; do
     if [[ "${success}" == "true" ]]; then
       yq -i -pj -oj -I=0 '.blocks[-1].text.text += ":white_check_mark: '"${name}"'\n"' ./slack-payload.json
     else
-      yq -pj -oj -I=0 '.[0].SpecReports | filter(.LeafNodeType == "It") | filter(.State == "failed")' "${report}" > "${report}-fails"
+      yq -pj -oj -I=0 '.[0].SpecReports | filter(.State == "failed")' "${report}" > "${report}-fails"
       failcount="$(yq -pj -oy 'length' "${report}-fails")"
       yq -i -pj -oj -I=0 '.blocks[-1].text.text += ":failed: '"${name}"' failure count: '"${failcount}"'\n"' ./slack-payload.json
 
       # Add failure message
       yq -i -pj -oj -I=0 '.blocks += {"type": "rich_text", "elements": [{"type": "rich_text_preformatted", "elements":[{"type":"text", "text":"- "}]}]}' ./slack-payload.json
-      yq -i -pj -oj -I=0 '.blocks[-1].elements[0].elements[0].text += (load("'"${report}-fails"'") | [.[] | .ContainerHierarchyTexts[0] + "\n  " + .LeafNodeText + "\n  " + (.Failure.Message | sub("\n", "\n    "))] | join("\n- "))' ./slack-payload.json
+      yq -i -pj -oj -I=0 '.blocks[-1].elements[0].elements[0].text += (load("'"${report}-fails"'") | [.[] | (.ContainerHierarchyTexts[0] // "[" + .LeafNodeType + "]") + "\n  " + .LeafNodeText + "\n  " + (.Failure.Message | sub("\n", "\n    "))] | join("\n- "))' ./slack-payload.json
       yq -i -pj -oj -I=0 '.blocks += {"type":"section","text":{"type":"mrkdwn","text":""}}' ./slack-payload.json
     fi
   else


### PR DESCRIPTION
Removes filter for "It" node types, allowing After/Before nodes to also be reported.

The empty text from https://redhat-internal.slack.com/archives/CUS1VB8P3/p1715427328187239 would now be:
```
- [AfterSuite]
  
  Timed out after 180.000s.
    Namespace grc-e2e-policy-generator should be deleted.
    Expected
        <bool>: false
    to be true
```