### PR TITLE
Fix import ManagedCluster script

### DIFF
--- a/build/import-managed.sh
+++ b/build/import-managed.sh
@@ -72,11 +72,11 @@ for idx in {1..6}; do
   echo "Waiting for ManagedClusterAddons to be available (${idx}/6)"
   kubectl get managedclusteraddons -n ${MANAGED_CLUSTER_NAME}
   kubectl wait managedclusteraddons -n ${MANAGED_CLUSTER_NAME} --all \
-    --for jsonpath='{.status.conditions[?(@.type=="Available")].status}'=True &&
+    --for=jsonpath='{.status.conditions[?(@.type=="Available")].status}'=True &&
     break || err_code=$?
 done
 
-kubectl get managedclusteraddons -n ${MANAGED_CLUSTER_NAME} --all
+kubectl get managedclusteraddons -n ${MANAGED_CLUSTER_NAME}
 
 if [[ "${err_code}" != "0" ]]; then
   echo "ManagedClusterAddons for ${MANAGED_CLUSTER_NAME} failed to become available."


### PR DESCRIPTION
```
error: jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3
error: unknown flag: --all
See 'kubectl get --help' for usage.
```
ref: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/51057/rehearse-51057-pull-ci-stolostron-governance-policy-framework-main-test-e2e-grc-framework/1788621143599484928/artifacts/test-e2e-grc-framework/e2e/build-log.txt

The `wait` command works for me locally, so I'm not sure whether there's just an older `kubectl` version in the CI...