### PR TITLE
Integration test enhancements/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-pod
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/doc/configuration-policy/audit/audit-pod-kind-field-filter.yaml
+++ b/doc/configuration-policy/audit/audit-pod-kind-field-filter.yaml
@@ -49,8 +49,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-pod-kind-field-filter
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/audit/audit-pod-kind.yaml
+++ b/doc/configuration-policy/audit/audit-pod-kind.yaml
@@ -47,8 +47,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-pod-kind
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/audit/audit-role-multiple-ns.yaml
+++ b/doc/configuration-policy/audit/audit-role-multiple-ns.yaml
@@ -57,8 +57,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-audit-multiple-ns
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/audit/audit-role-single-ns.yaml
+++ b/doc/configuration-policy/audit/audit-role-single-ns.yaml
@@ -51,8 +51,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-audit-single-ns
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/create/create-role-multiple-ns.yaml
+++ b/doc/configuration-policy/create/create-role-multiple-ns.yaml
@@ -62,8 +62,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/create/create-role-single-ns.yaml
+++ b/doc/configuration-policy/create/create-role-single-ns.yaml
@@ -57,8 +57,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-create
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/delete/delete-role-multiple-ns.yaml
+++ b/doc/configuration-policy/delete/delete-role-multiple-ns.yaml
@@ -50,8 +50,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/delete/delete-role-single-ns.yaml
+++ b/doc/configuration-policy/delete/delete-role-single-ns.yaml
@@ -45,8 +45,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-delete
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/gatekeeper/gatekeeper-install.yaml
+++ b/doc/configuration-policy/gatekeeper/gatekeeper-install.yaml
@@ -129,8 +129,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/gatekeeper/gatekeeper-policy-sample.yaml
+++ b/doc/configuration-policy/gatekeeper/gatekeeper-policy-sample.yaml
@@ -120,8 +120,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-sample
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/merge-patch/merge-patch-role-multiple-ns.yaml
+++ b/doc/configuration-policy/merge-patch/merge-patch-role-multiple-ns.yaml
@@ -57,8 +57,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-merge-patch
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/merge-patch/merge-patch-role-single-ns.yaml
+++ b/doc/configuration-policy/merge-patch/merge-patch-role-single-ns.yaml
@@ -52,8 +52,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-merge-patch
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/replace-patch/replace-patch-role-multiple-ns.yaml
+++ b/doc/configuration-policy/replace-patch/replace-patch-role-multiple-ns.yaml
@@ -57,8 +57,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-replace-patch
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/doc/configuration-policy/replace-patch/replace-patch-role-single-ns.yaml
+++ b/doc/configuration-policy/replace-patch/replace-patch-role-single-ns.yaml
@@ -52,8 +52,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-role-replace-patch
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -90,7 +90,7 @@ func DoCreatePolicyTest(policyFile string, templateGVRs ...schema.GroupVersionRe
 
 	if ManuallyPatchDecisions {
 		plrName := policyName + "-plr"
-		By("Patching " + plrName + " with decision of cluster " + UserNamespace)
+		By("Patching " + plrName + " with decision of cluster " + ClusterNamespaceOnHub)
 		plr := utils.GetWithTimeout(
 			ClientHubDynamic, GvrPlacementRule, plrName, UserNamespace, true, DefaultTimeoutSeconds,
 		)

--- a/test/common/policy_utils.go
+++ b/test/common/policy_utils.go
@@ -49,6 +49,9 @@ func GetClusterComplianceState(policyName, clusterName string) func(Gomega) inte
 // Patches the clusterSelector of the specified PlacementRule so that it will
 // always only match the targetCluster.
 func PatchPlacementRule(namespace, name string) error {
+	By("Patching PlacementRule " + namespace + "/" + name +
+		" with clusterSelector {name: " + ClusterNamespaceOnHub + "}")
+
 	_, err := OcHub(
 		"patch",
 		"-n",

--- a/test/e2e/policySet_e2e_test.go
+++ b/test/e2e/policySet_e2e_test.go
@@ -35,16 +35,21 @@ var _ = Describe("Test policy set", func() {
 			)
 			Expect(rootPolicy).NotTo(BeNil())
 
-			By("Patching " + testPolicySetName + "-plr with decision of cluster managed")
-			plr := utils.GetWithTimeout(
-				clientHubDynamic, common.GvrPlacementRule, testPolicySetName+"-plr", userNamespace,
-				true, defaultTimeoutSeconds,
-			)
-			plr.Object["status"] = utils.GeneratePlrStatus(clusterNamespaceOnHub)
-			_, err = clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(
-				context.TODO(), plr, metav1.UpdateOptions{},
-			)
+			err = common.PatchPlacementRule(userNamespace, testPolicySetName+"-plr")
 			Expect(err).ToNot(HaveOccurred())
+
+			if common.ManuallyPatchDecisions {
+				By("Patching " + testPolicySetName + "-plr with decision of cluster " + clusterNamespaceOnHub)
+				plr := utils.GetWithTimeout(
+					clientHubDynamic, common.GvrPlacementRule, testPolicySetName+"-plr", userNamespace,
+					true, defaultTimeoutSeconds,
+				)
+				plr.Object["status"] = utils.GeneratePlrStatus(clusterNamespaceOnHub)
+				_, err = clientHubDynamic.Resource(common.GvrPlacementRule).Namespace(userNamespace).UpdateStatus(
+					context.TODO(), plr, metav1.UpdateOptions{},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			By("Checking " + testPolicyName + " on managed cluster in ns " + clusterNamespaceOnHub)
 			managedplc := utils.GetWithTimeout(

--- a/test/integration/policy_certificate_test.go
+++ b/test/integration/policy_certificate_test.go
@@ -71,7 +71,6 @@ var _ = Describe(
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyCertificateName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_comp_operator_test.go
+++ b/test/integration/policy_comp_operator_test.go
@@ -32,7 +32,6 @@ func complianceScanTest(scanPolicyName string, scanPolicyURL string, scanName st
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+scanPolicyName)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -251,7 +250,6 @@ var _ = Describe("RHACM4K-2222 GRC: [P1][Sev1][policy-grc] "+
 				"--kubeconfig="+kubeconfigHub,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+compPolicyName)
 			Expect(err).ToNot(HaveOccurred())
 			By("Checking " + compPolicyName + " on hub cluster in ns " + userNamespace)

--- a/test/integration/policy_diff_generation_test.go
+++ b/test/integration/policy_diff_generation_test.go
@@ -37,7 +37,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test diff generation",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyConfigMapName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_etcdencryption_test.go
+++ b/test/integration/policy_etcdencryption_test.go
@@ -36,7 +36,6 @@ var _ = Describe(
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyEtcdEncryptionName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_gatekeeper_operator_downstream_test.go
+++ b/test/integration/policy_gatekeeper_operator_downstream_test.go
@@ -51,7 +51,6 @@ var _ = Describe("RHACM4K-3055", Ordered, Label("policy-collection", "stable", "
 				"--kubeconfig="+kubeconfigHub,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+gatekeeperPolicyName)
 			Expect(err).ToNot(HaveOccurred())
 			By("Checking policy-gatekeeper-operator on hub cluster in ns " + userNamespace)

--- a/test/integration/policy_imagemanifest_test.go
+++ b/test/integration/policy_imagemanifest_test.go
@@ -37,7 +37,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Patching placement rule")
 		err = common.PatchPlacementRule(userNamespace, "placement-"+policyIMVName)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_install_operator_test.go
+++ b/test/integration/policy_install_operator_test.go
@@ -98,7 +98,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 				_, err := common.OcHub("apply", "-f", policyNoGroupYAML, "-n", userNamespace)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Patching the placement rule")
 				err = common.PatchPlacementRule(userNamespace, policyNamePrefix+noGroupSuffix+"-plr")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -305,8 +304,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test install Operator",
 			It(policyNamePrefix+withGroupSuffix+" should be created on the hub", func() {
 				_, err := common.OcHub("apply", "-f", policyWithGroupYAML, "-n", userNamespace)
 				Expect(err).ToNot(HaveOccurred())
-
-				By("Patching the placement rule")
 				err = common.PatchPlacementRule(userNamespace, policyNamePrefix+withGroupSuffix+"-plr")
 				Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_limitmemory_test.go
+++ b/test/integration/policy_limitmemory_test.go
@@ -62,7 +62,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-limitmemory policy
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyLimitMemoryName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_multiline_templatization_test.go
+++ b/test/integration/policy_multiline_templatization_test.go
@@ -93,19 +93,19 @@ var _ = Describe(
 				} {
 					By(fmt.Sprintf("Checking edited ConfigMap %s/%s on the %s cluster", userNamespace, name, cluster))
 					Eventually(
-						func() string {
+						func() (map[string]string, error) {
 							configMap, err := client.CoreV1().ConfigMaps(userNamespace).Get(
 								ctx, name, metav1.GetOptions{},
 							)
-							if err != nil {
-								return ""
-							}
 
-							return configMap.Data["extraData"]
-						},
-						defaultTimeoutSeconds*2,
-						1,
-					).Should(Equal("exists!"))
+							return configMap.Data, err
+						}, defaultTimeoutSeconds*2, 1,
+					).Should(
+						HaveKeyWithValue("extraData", "exists!"),
+						fmt.Sprintf("ConfigMap %s/%s on the %s cluster should have expected data",
+							userNamespace, name, cluster,
+						),
+					)
 				}
 			}
 		})
@@ -128,17 +128,19 @@ var _ = Describe(
 				} {
 					By(fmt.Sprintf("Checking copied ConfigMap %s/%s on the %s cluster", configNamespace, name, cluster))
 					Eventually(
-						func() string {
+						func() (map[string]string, error) {
 							configMap, err := client.CoreV1().ConfigMaps(configNamespace).Get(
 								ctx, name+"-copy", metav1.GetOptions{},
 							)
-							if err != nil {
-								return ""
-							}
 
-							return configMap.Data["extraData"]
+							return configMap.Data, err
 						}, defaultTimeoutSeconds*2, 1,
-					).Should(Equal("exists!"))
+					).Should(
+						HaveKeyWithValue("extraData", "exists!"),
+						fmt.Sprintf("ConfigMap %s/%s on the %s cluster should have expected data",
+							configNamespace, name, cluster,
+						),
+					)
 				}
 			}
 		})

--- a/test/integration/policy_namespace_test.go
+++ b/test/integration/policy_namespace_test.go
@@ -31,7 +31,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-namespace policy",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyNamespaceName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_pod_test.go
+++ b/test/integration/policy_pod_test.go
@@ -62,7 +62,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-pod policy",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyPodName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_psp_test.go
+++ b/test/integration/policy_psp_test.go
@@ -58,7 +58,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-psp policy",
 		})
 
 		It("stable/"+rootPolicyName+" should be created on the managed cluster", func() {
-			By("Patching placement rule placement-" + rootPolicyName)
 			err := common.PatchPlacementRule(userNamespace, "placement-"+rootPolicyName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_role_test.go
+++ b/test/integration/policy_role_test.go
@@ -60,7 +60,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-role policy",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyRoleName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_rolebinding_test.go
+++ b/test/integration/policy_rolebinding_test.go
@@ -56,7 +56,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-rolebinding policy
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+policyRoleBindingName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_scc_test.go
+++ b/test/integration/policy_scc_test.go
@@ -33,7 +33,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the policy-scc policy",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Patching placement rule")
 			err = common.PatchPlacementRule(userNamespace, "placement-"+rootPolicyName)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_set_test.go
+++ b/test/integration/policy_set_test.go
@@ -56,7 +56,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test policy set", Ordered, Label("
 			Expect(found).Should(BeTrue())
 			Expect(templates).Should(HaveLen(1))
 
-			By("Patching placement rule " + testPolicySetName + "-plr")
 			err = testcommon.PatchPlacementRule(userNamespace, testPolicySetName+"-plr")
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/integration/policy_zts_cmc_test.go
+++ b/test/integration/policy_zts_cmc_test.go
@@ -44,7 +44,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test "+
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Patching placement rule")
 		err = common.PatchPlacementRule(userNamespace, "placement-"+policyName)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/performance/resources/templates/cfgmap-plc.yaml
+++ b/test/performance/resources/templates/cfgmap-plc.yaml
@@ -85,7 +85,6 @@ spec:
         operator: In
         values:
           - "true"
-  clusterConditions: []
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/policy_ordering.go
+++ b/test/policy_ordering.go
@@ -138,16 +138,21 @@ func PolicyOrdering(labels ...string) bool {
 				)
 				Expect(rootPolicy).NotTo(BeNil())
 
-				By("Patching " + testPolicySetName + "-plr with decision of cluster managed")
-				plr := utils.GetWithTimeout(
-					ClientHubDynamic, GvrPlacementRule, testPolicySetName+"-plr", UserNamespace,
-					true, DefaultTimeoutSeconds,
-				)
-				plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespaceOnHub)
-				_, err = ClientHubDynamic.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
-					context.TODO(), plr, metav1.UpdateOptions{},
-				)
+				err = PatchPlacementRule(UserNamespace, testPolicySetName+"-plr")
 				Expect(err).ToNot(HaveOccurred())
+
+				if ManuallyPatchDecisions {
+					By("Patching " + testPolicySetName + "-plr with decision of cluster " + ClusterNamespaceOnHub)
+					plr := utils.GetWithTimeout(
+						ClientHubDynamic, GvrPlacementRule, testPolicySetName+"-plr", UserNamespace,
+						true, DefaultTimeoutSeconds,
+					)
+					plr.Object["status"] = utils.GeneratePlrStatus(ClusterNamespaceOnHub)
+					_, err = ClientHubDynamic.Resource(GvrPlacementRule).Namespace(UserNamespace).UpdateStatus(
+						context.TODO(), plr, metav1.UpdateOptions{},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Checking " + testPolicyName + " on managed cluster in ns " + ClusterNamespaceOnHub)
 				managedplc := utils.GetWithTimeout(

--- a/test/resources/cert_policy/cert-policy.yaml
+++ b/test/resources/cert_policy/cert-policy.yaml
@@ -46,9 +46,5 @@ kind: PlacementRule
 metadata:
   name: cert-policy-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy/role-policy-musthave.yaml
+++ b/test/resources/configuration_policy/role-policy-musthave.yaml
@@ -53,9 +53,5 @@ kind: PlacementRule
 metadata:
   name: role-policy-musthave-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy/role-policy-mustnothave.yaml
+++ b/test/resources/configuration_policy/role-policy-mustnothave.yaml
@@ -53,9 +53,5 @@ kind: PlacementRule
 metadata:
   name: role-policy-mustnothave-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy/role-policy-mustonlyhave.yaml
+++ b/test/resources/configuration_policy/role-policy-mustonlyhave.yaml
@@ -53,9 +53,5 @@ kind: PlacementRule
 metadata:
   name: role-policy-mustonlyhave-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-all.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-all.yaml
@@ -49,7 +49,5 @@ kind: PlacementRule
 metadata:
   name: cm-policy-prune-all-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-default.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-default.yaml
@@ -48,7 +48,5 @@ kind: PlacementRule
 metadata:
   name: cm-policy-prune-default-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-if-created.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-if-created.yaml
@@ -49,7 +49,5 @@ kind: PlacementRule
 metadata:
   name: cm-policy-prune-if-created-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/configuration_policy_prune/cm-policy-prune-none.yaml
+++ b/test/resources/configuration_policy_prune/cm-policy-prune-none.yaml
@@ -49,7 +49,5 @@ kind: PlacementRule
 metadata:
   name: cm-policy-prune-none-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/hub_templates_encryption/test-hub-encryption.yaml
+++ b/test/resources/hub_templates_encryption/test-hub-encryption.yaml
@@ -57,9 +57,5 @@ kind: PlacementRule
 metadata:
   name: test-hub-encryption-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/hub_templates_managedclusterlabels/mclabels-fromcm-pol.yaml
+++ b/test/resources/hub_templates_managedclusterlabels/mclabels-fromcm-pol.yaml
@@ -44,9 +44,5 @@ kind: PlacementRule
 metadata:
   name: mclabels-fromcm-pol-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/hub_templates_managedclusterlabels/mclabels-range-pol.yaml
+++ b/test/resources/hub_templates_managedclusterlabels/mclabels-range-pol.yaml
@@ -46,9 +46,5 @@ kind: PlacementRule
 metadata:
   name: mclabels-range-pol-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/policy_hub_templates_21440/policy-hub-templates-21440.yaml
+++ b/test/resources/policy_hub_templates_21440/policy-hub-templates-21440.yaml
@@ -42,8 +42,5 @@ kind: PlacementRule
 metadata:
   name: policy-hub-templates-21440-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_info_metric/compliant.yaml
+++ b/test/resources/policy_info_metric/compliant.yaml
@@ -45,8 +45,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-metric-compliant
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_info_metric/noncompliant.yaml
+++ b/test/resources/policy_info_metric/noncompliant.yaml
@@ -45,8 +45,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-metric-noncompliant
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_multiline_templatization/policy-multiline-template-hub.yaml
+++ b/test/resources/policy_multiline_templatization/policy-multiline-template-hub.yaml
@@ -47,8 +47,5 @@ kind: PlacementRule
 metadata:
   name: policy-multiline-template-hub-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_multiline_templatization/policy-multiline-template-nohub.yaml
+++ b/test/resources/policy_multiline_templatization/policy-multiline-template-nohub.yaml
@@ -47,8 +47,5 @@ kind: PlacementRule
 metadata:
   name: policy-multiline-template-nohub-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_ordering/dep-plcset.yaml
+++ b/test/resources/policy_ordering/dep-plcset.yaml
@@ -59,9 +59,5 @@ kind: PlacementRule
 metadata:
   name: test-policyset-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/policy_report_metric/compliant.yaml
+++ b/test/resources/policy_report_metric/compliant.yaml
@@ -45,8 +45,5 @@ kind: PlacementRule
 metadata:
   name: placement-policyreport-metric-noncompliant
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_report_metric/noncompliant.yaml
+++ b/test/resources/policy_report_metric/noncompliant.yaml
@@ -45,8 +45,5 @@ kind: PlacementRule
 metadata:
   name: placement-policyreport-metric-noncompliant
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []

--- a/test/resources/policy_set/test-policyset.yaml
+++ b/test/resources/policy_set/test-policyset.yaml
@@ -59,9 +59,5 @@ kind: PlacementRule
 metadata:
   name: test-policyset-plr
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/template-sync-errors/invalid-cr-template.yaml
+++ b/test/resources/template-sync-errors/invalid-cr-template.yaml
@@ -49,7 +49,5 @@ kind: PlacementRule
 metadata:
   name: invalid-cr-template-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/template-sync-errors/pretend-policy-template.yaml
+++ b/test/resources/template-sync-errors/pretend-policy-template.yaml
@@ -50,7 +50,5 @@ kind: PlacementRule
 metadata:
   name: pretend-policy-template-plr
 spec:
-  clusterConditions: []
   clusterSelector:
-    matchExpressions:
-      []
+    matchExpressions: []

--- a/test/resources/verify_metrics/noncompliant.yaml
+++ b/test/resources/verify_metrics/noncompliant.yaml
@@ -40,8 +40,5 @@ kind: PlacementRule
 metadata:
   name: placement-policy-verify-metrics-noncompliant
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions: []


### PR DESCRIPTION
Among some minor changes, the major updates here are:
- Remove any remaining `ManagedClusterConditionAvailable` (this might cut down on Canary flakes also!)
- Don't patch placement in Prow (this is unnecessary since it's a full ACM install, and it was also getting in the way of running tests with a managed cluster from proceeding properly)