### PR TITLE
Update OperatorPolicy tests for upgradeApproval

### DIFF
--- a/test/integration/operator_policy_error_test.go
+++ b/test/integration/operator_policy_error_test.go
@@ -99,13 +99,13 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test operatorpolicy errors",
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It(operatorPolicyName+" should be patched with incorrect installPlanApproval", func() {
+		It(operatorPolicyName+" should be patched to specify installPlanApproval", func() {
 			_, err := common.OcHub(
 				"patch", "policies.policy.open-cluster-management.io", policyName,
 				"-n", userNamespace, "--type=json", "-p", `[{
 				"op":"replace", 
 				"path":"/spec/policy-templates/0/objectDefinition/spec/subscription/installPlanApproval",
-				"value":"Invalid"
+				"value":"Automatic"
 			}]`)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -121,6 +121,6 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test operatorpolicy errors",
 				common.GetOpPolicyCompMsg(operatorPolicyName),
 				defaultTimeoutSeconds,
 				1,
-			).Should(ContainSubstring("the policy spec.subscription.installPlanApproval ('Invalid') is invalid"))
+			).Should(ContainSubstring("installPlanApproval is prohibited in spec.subscription"))
 		})
 	})

--- a/test/resources/compliance_history/operator-policy-invalid.yaml
+++ b/test/resources/compliance_history/operator-policy-invalid.yaml
@@ -21,10 +21,10 @@ spec:
             channel: stable-3.8
             name: quay-operator
             namespace: ch-operator-policy-test-ns
-            installPlanApproval: Automatic
             # correct one: redhat-operators
             source: invalid
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement

--- a/test/resources/compliance_history/policy-install-gk.yaml
+++ b/test/resources/compliance_history/policy-install-gk.yaml
@@ -19,9 +19,9 @@ spec:
             channel: stable
             name: gatekeeper-operator-product
             namespace: openshift-operators
-            installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy

--- a/test/resources/operator_policy/test-op-err-correct.yaml
+++ b/test/resources/operator_policy/test-op-err-correct.yaml
@@ -22,9 +22,9 @@ spec:
             channel: stable-3.8
             name: quay-operator
             namespace: grcqeoptest-ns-43568
-            installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/operator_policy/test-op-err-initial.yaml
+++ b/test/resources/operator_policy/test-op-err-initial.yaml
@@ -22,9 +22,9 @@ spec:
             channel: stable-3.8
             name: quay-operator
             namespace: grcqeoptest-notcreated
-            installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
+++ b/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
@@ -20,7 +20,7 @@ spec:
           subscription:
             name: quay-operator
             namespace: grcqeoptest-ns-47229
-            installPlanApproval: Automatic
+          upgradeApproval: Automatic
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/operator_policy_no_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_no_group.yaml
@@ -21,9 +21,9 @@ spec:
             channel: stable-3.8
             name: quay-operator
             namespace: grcqeoptest-ns-43544
-            installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/operator_policy_with_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_with_group.yaml
@@ -26,9 +26,9 @@ spec:
             channel: stable-3.8
             name: quay-operator
             namespace: grcqeoptest-ns-43545
-            installPlanApproval: Automatic
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+          upgradeApproval: Automatic
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
Per a recent change in the controller, it is now invalid to specify installPlanApproval in an OperatorPolicy, and it is necessary to specify upgradeApproval.

Refs:
 - https://github.com/open-cluster-management-io/config-policy-controller/pull/249