### PR TITLE
Skip unavailable clusters in OperatorPolicy defaults test

### DIFF
--- a/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
+++ b/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
@@ -42,3 +42,6 @@ metadata:
 spec:
   clusterSelector:
     matchExpressions: []
+  clusterConditions:
+  - type: ManagedClusterConditionAvailable
+    status: "True"

--- a/test/resources/policy_install_operator/operator_policy_no_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_no_group.yaml
@@ -45,3 +45,6 @@ metadata:
 spec:
   clusterSelector:
     matchExpressions: []
+  clusterConditions:
+  - type: ManagedClusterConditionAvailable
+    status: "True"

--- a/test/resources/policy_install_operator/operator_policy_with_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_with_group.yaml
@@ -50,3 +50,6 @@ metadata:
 spec:
   clusterSelector:
     matchExpressions: []
+  clusterConditions:
+  - type: ManagedClusterConditionAvailable
+    status: "True"


### PR DESCRIPTION
When a cluster is imported but not available due to a failed deployment, the policy can never become compliant.

Relates:
https://github.com/stolostron/backlog/issues/27628