### PR TITLE
Filter out clusters where GRC is unavailable

### DIFF
--- a/test/resources/compliance_history/cert-policy.yaml
+++ b/test/resources/compliance_history/cert-policy.yaml
@@ -29,7 +29,13 @@ kind: Placement
 metadata:
   name: compliance-history-test
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/cert-prereq.yaml
+++ b/test/resources/compliance_history/cert-prereq.yaml
@@ -47,7 +47,13 @@ kind: Placement
 metadata:
   name: ch-cert-prereq
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/operator-policy-invalid.yaml
+++ b/test/resources/compliance_history/operator-policy-invalid.yaml
@@ -31,7 +31,13 @@ kind: Placement
 metadata:
   name: compliance-history-test
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/operator-prereq.yaml
+++ b/test/resources/compliance_history/operator-prereq.yaml
@@ -32,7 +32,13 @@ kind: Placement
 metadata:
   name: ch-operator-prereq
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy-gk-prereq.yaml
+++ b/test/resources/compliance_history/policy-gk-prereq.yaml
@@ -39,7 +39,13 @@ kind: Placement
 metadata:
   name: compliance-api-gk-prereq
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy-gk-prereq2.yaml
+++ b/test/resources/compliance_history/policy-gk-prereq2.yaml
@@ -41,7 +41,13 @@ kind: Placement
 metadata:
   name: compliance-api-gk-prereq
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy-gk.yaml
+++ b/test/resources/compliance_history/policy-gk.yaml
@@ -111,7 +111,13 @@ kind: Placement
 metadata:
   name: compliance-api-gk
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy-install-gk.yaml
+++ b/test/resources/compliance_history/policy-install-gk.yaml
@@ -70,7 +70,13 @@ kind: Placement
 metadata:
   name: compliance-api-install-gk
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy-uninstall-gk.yaml
+++ b/test/resources/compliance_history/policy-uninstall-gk.yaml
@@ -66,7 +66,13 @@ kind: Placement
 metadata:
   name: compliance-api-uninstall-gk
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/compliance_history/policy.yaml
+++ b/test/resources/compliance_history/policy.yaml
@@ -46,7 +46,13 @@ kind: Placement
 metadata:
   name: compliance-api-configpolicy
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/policy_install_operator/clean-up-grcqeoptest-ns.yaml
+++ b/test/resources/policy_install_operator/clean-up-grcqeoptest-ns.yaml
@@ -44,4 +44,9 @@ metadata:
   name: cleanup-grcqeoptest-ns
 spec:
   clusterSelector:
-    matchExpressions: []
+    matchLabels:
+      feature.open-cluster-management.io/addon-config-policy-controller: "available"
+      feature.open-cluster-management.io/addon-governance-policy-framework: "available"
+  clusterConditions:
+    - type: ManagedClusterConditionAvailable
+      status: "True"

--- a/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
+++ b/test/resources/policy_install_operator/operator_policy_all_defaults.yaml
@@ -41,7 +41,9 @@ metadata:
   name: test-op-47229
 spec:
   clusterSelector:
-    matchExpressions: []
+    matchLabels:
+      feature.open-cluster-management.io/addon-config-policy-controller: "available"
+      feature.open-cluster-management.io/addon-governance-policy-framework: "available"
   clusterConditions:
   - type: ManagedClusterConditionAvailable
     status: "True"

--- a/test/resources/policy_install_operator/operator_policy_no_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_no_group.yaml
@@ -44,7 +44,9 @@ metadata:
   name: test-op-43544-plr
 spec:
   clusterSelector:
-    matchExpressions: []
+    matchLabels:
+      feature.open-cluster-management.io/addon-config-policy-controller: "available"
+      feature.open-cluster-management.io/addon-governance-policy-framework: "available"
   clusterConditions:
   - type: ManagedClusterConditionAvailable
     status: "True"

--- a/test/resources/policy_install_operator/operator_policy_with_group.yaml
+++ b/test/resources/policy_install_operator/operator_policy_with_group.yaml
@@ -49,7 +49,9 @@ metadata:
   name: test-op-43545-plr
 spec:
   clusterSelector:
-    matchExpressions: []
+    matchLabels:
+      feature.open-cluster-management.io/addon-config-policy-controller: "available"
+      feature.open-cluster-management.io/addon-governance-policy-framework: "available"
   clusterConditions:
   - type: ManagedClusterConditionAvailable
     status: "True"

--- a/test/resources/recreate_option/policy-configmap.yaml
+++ b/test/resources/recreate_option/policy-configmap.yaml
@@ -31,7 +31,13 @@ kind: Placement
 metadata:
   name: recreate-option-all
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/recreate_option/policy-initial-deployment.yaml
+++ b/test/resources/recreate_option/policy-initial-deployment.yaml
@@ -48,7 +48,13 @@ kind: Placement
 metadata:
   name: recreate-option-initial
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/recreate_option/policy-update-deployment.yaml
+++ b/test/resources/recreate_option/policy-update-deployment.yaml
@@ -49,7 +49,13 @@ kind: Placement
 metadata:
   name: recreate-option-update
   namespace: open-cluster-management-global-set
-spec: {}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            feature.open-cluster-management.io/addon-config-policy-controller: "available"
+            feature.open-cluster-management.io/addon-governance-policy-framework: "available"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
This will help in the tests that apply to all clusters since sometimes a managed cluster fails to fully provision but still gets selected.