### PR TITLE
Replace `WithOffset()` with `GinkgoHelper()`

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -294,15 +294,17 @@ func IsAtLeastVersion(minVersion string) bool {
 }
 
 func CleanupHubNamespace(namespace string) {
+	GinkgoHelper()
+
 	By("Deleting namespace " + namespace)
 
 	err := ClientHub.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
 	if !k8serrors.IsNotFound(err) {
-		ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	// Wait for the namespace to be fully deleted before proceeding.
-	EventuallyWithOffset(1,
+	Eventually(
 		func() bool {
 			_, err := ClientHub.CoreV1().Namespaces().Get(
 				context.TODO(), namespace, metav1.GetOptions{},

--- a/test/e2e/cert_policy_test.go
+++ b/test/e2e/cert_policy_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Test cert policy", func() {
 				"--field-selector=involvedObject.name="+common.UserNamespace+"."+certPolicyName,
 				"--ignore-not-found",
 			)
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/test/e2e/configuration_policy_test.go
+++ b/test/e2e/configuration_policy_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func configPolicyTestCleanUp(rolePolicyName, rolePolicyYAML string) {
+	GinkgoHelper()
+
 	const roleName string = "role-policy-e2e"
 
 	By("Deleting the role, policy, and events on managed cluster")
@@ -26,24 +28,24 @@ func configPolicyTestCleanUp(rolePolicyName, rolePolicyYAML string) {
 		"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
 		"--ignore-not-found",
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	_, err = common.OcHosting(
 		"delete", "events", "-n", common.ClusterNamespace,
 		"--field-selector=involvedObject.name="+rolePolicyName,
 		"--ignore-not-found",
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	_, err = common.OcHub(
 		"delete", "events", "-n", common.ClusterNamespaceOnHub,
 		"--field-selector=involvedObject.name="+common.UserNamespace+"."+rolePolicyName,
 		"--ignore-not-found",
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	_, err = common.OcManaged(
 		"delete", "role", "-n", "default", roleName,
 		"--ignore-not-found",
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 }
 
 var _ = Describe("Test configuration policy inform", Ordered, func() {

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -72,7 +71,7 @@ func init() {
 	common.InitFlags(nil)
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	By("Setup hub and managed client")
 	common.InitInterfaces(common.KubeconfigHub, common.KubeconfigManaged, common.IsHosted)
 	kubeconfigHub = common.KubeconfigHub
@@ -91,23 +90,23 @@ var _ = BeforeSuite(func() {
 	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()
 	if _, err := namespaces.Get(
-		context.TODO(),
+		ctx,
 		userNamespace,
 		metav1.GetOptions{},
 	); err != nil && errors.IsNotFound(err) {
-		Expect(namespaces.Create(context.TODO(), &corev1.Namespace{
+		Expect(namespaces.Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: userNamespace,
 			},
 		}, metav1.CreateOptions{})).NotTo(BeNil())
 	}
-	Expect(namespaces.Get(context.TODO(), userNamespace, metav1.GetOptions{})).NotTo(BeNil())
+	Expect(namespaces.Get(ctx, userNamespace, metav1.GetOptions{})).NotTo(BeNil())
 
 	By("Setting up GitOps user")
-	common.GitOpsUserSetup(&gitopsUser)
+	common.GitOpsUserSetup(ctx, &gitopsUser)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	By("Delete Namespace if needed")
 	_, err := common.OcHub(
 		"delete", "namespace", userNamespace,
@@ -121,7 +120,7 @@ var _ = AfterSuite(func() {
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	common.GitOpsCleanup(gitopsUser)
+	common.GitOpsCleanup(ctx, gitopsUser)
 })
 
 func canCreateOpenshiftNamespaces() bool {

--- a/test/integration/verify_metrics_test.go
+++ b/test/integration/verify_metrics_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -62,7 +61,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test required metrics are availabl
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Verifies all required metrics are available", func() {
+	It("Verifies all required metrics are available", func(ctx SpecContext) {
 		By("Creating a noncompliant policy")
 		_, err := common.OcHub("apply", "-f", noncompliantPolicyYAML, "-n", userNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +73,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test required metrics are availabl
 
 		By("Finding the Prometheus route")
 		route, err := clientHubDynamic.Resource(common.GvrRoute).Namespace(monitoringNS).Get(
-			context.TODO(), prometheusRouteName, metav1.GetOptions{},
+			ctx, prometheusRouteName, metav1.GetOptions{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -135,7 +134,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test required metrics are availabl
 				req.URL.RawQuery = q.Encode()
 
 				res, err := httpClient.Do(req)
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred(), "Unexpected error sending request to Prometheus")
 
 				resBody, err := io.ReadAll(res.Body)
 				g.Expect(err).ToNot(HaveOccurred())
@@ -150,7 +149,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test required metrics are availabl
 
 				result, ok := data["result"].([]interface{})
 				g.Expect(ok).To(BeTrue())
-				g.Expect(result).ToNot(BeEmpty())
+				g.Expect(result).ToNot(BeEmpty(), "Expected metrics for "+metric)
 			}, "60s", 1).Should(Succeed())
 		}
 	})


### PR DESCRIPTION
Also:
- Passes `SpecContext` to metrics test, GitOps setup functions,  and Before/After suites.
- Adds additional description to metrics test.