### PR TITLE
Simplify the Gatekeeper uninstall

### DIFF
--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -435,8 +435,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Deleting the CSV from every namespace takes the ConfigurationPolicy quite a while (~5 min)
-			_ = verifyPolicyOnAllClusters(ctx, policyNS, uninstallGKPolicyName, "Compliant", defaultTimeoutSeconds*12)
+			_ = verifyPolicyOnAllClusters(ctx, policyNS, uninstallGKPolicyName, "Compliant", defaultTimeoutSeconds*2)
 
 			By("Delete the " + uninstallGKPolicyName + " policy")
 			_, err = common.OcHub(

--- a/test/resources/compliance_history/policy-uninstall-gk.yaml
+++ b/test/resources/compliance_history/policy-uninstall-gk.yaml
@@ -10,10 +10,9 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-api-uninstall-gk-sub
+          name: compliance-api-uninstall-gk
         spec:
           object-templates-raw: |
-
             {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gatekeepers.operator.gatekeeper.sh").metadata.name) "" }}
             - complianceType: mustnothave
               objectDefinition:
@@ -29,23 +28,7 @@ spec:
                 metadata:
                   name: gatekeeper-operator-product
                   namespace: openshift-operators
-          remediationAction: enforce
-          severity: critical
-    - extraDependencies:
-      - apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        name: compliance-api-uninstall-gk-sub
-        compliance: Compliant
-      objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: compliance-api-uninstall-gk-csv
-        spec:
-          object-templates-raw: |
-
-            {{ range $ns := (lookup "v1" "Namespace" "" "").items }}
-            {{ range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion"  "" "").items }}
+            {{ range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion"  "openshift-operators" "").items }}
             {{ $csvName := $csv.metadata.name }}
             {{ if hasPrefix "gatekeeper-operator-product." $csvName }}
             - complianceType: mustnothave
@@ -54,8 +37,7 @@ spec:
                 kind: ClusterServiceVersion
                 metadata:
                   name: {{ $csvName }}
-                  namespace: {{ $ns.metadata.name }}
-            {{ end }}
+                  namespace: openshift-operators
             {{ end }}
             {{ end }}
           remediationAction: enforce


### PR DESCRIPTION
Only the "real" CSV in the subscription namespace needs to be deleted. The others are copies that get cleaned up automatically. This should make the test faster and more stable.