### PR TITLE
Fix the Gatekeeper operator uninstall

### DIFF
--- a/test/integration/compliance_history_test.go
+++ b/test/integration/compliance_history_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
 
 	"github.com/stolostron/governance-policy-framework/test/common"
 )
@@ -197,7 +198,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 		_, err := common.OcHub(
 			"delete",
 			"-f",
-			"../resources/compliance_history/policy-uninstall-gk.yaml",
+			"../resources/gatekeeper/policy-uninstall-gk.yaml",
 			"--ignore-not-found",
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -405,7 +406,7 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 
 	It("Creates a policy with a Gatekeeper constraint", func(ctx context.Context) {
 		const installGKPolicyName = "compliance-api-install-gk"
-		const uninstallGKPolicyName = "compliance-api-uninstall-gk"
+		const uninstallGKPolicyName = "uninstall-gk"
 		const gkPrereqPolicyName = "compliance-api-gk-prereq"
 		const gkPolicyName = "compliance-api-gk"
 
@@ -430,8 +431,10 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			By("Creating the " + uninstallGKPolicyName + " policy to uninstall Gatekeeper")
 			_, err = common.OcHub(
 				"apply",
+				"-n",
+				userNamespace,
 				"-f",
-				"../resources/compliance_history/policy-uninstall-gk.yaml",
+				"../resources/gatekeeper/policy-uninstall-gk.yaml",
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -440,10 +443,20 @@ var _ = Describe("GRC: [P1][Sev1][policy-grc] Test the compliance history API", 
 			By("Delete the " + uninstallGKPolicyName + " policy")
 			_, err = common.OcHub(
 				"delete",
+				"-n",
+				userNamespace,
 				"-f",
-				"../resources/compliance_history/policy-uninstall-gk.yaml",
+				"../resources/gatekeeper/policy-uninstall-gk.yaml",
 			)
 			Expect(err).ToNot(HaveOccurred())
+
+			utils.Kubectl(
+				"delete",
+				"namespace",
+				"openshift-gatekeeper-system",
+				"--kubeconfig="+kubeconfigManaged,
+				"--ignore-not-found",
+			)
 		})
 
 		By("Creating an invalid ConfigMap with a policy")

--- a/test/resources/gatekeeper/policy-uninstall-gk.yaml
+++ b/test/resources/gatekeeper/policy-uninstall-gk.yaml
@@ -1,8 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: compliance-api-uninstall-gk
-  namespace: policy-test
+  name: uninstall-gk
 spec:
   disabled: false
   policy-templates:
@@ -10,7 +9,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-api-uninstall-gk
+          name: uninstall-gk
         spec:
           object-templates-raw: |
             {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "gatekeepers.operator.gatekeeper.sh").metadata.name) "" }}
@@ -46,8 +45,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  name: compliance-api-uninstall-gk
-  namespace: policy-test
+  name: uninstall-gk
 spec:
   predicates:
     - requiredClusterSelector:
@@ -59,13 +57,12 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: compliance-api-uninstall-gk
-  namespace: policy-test
+  name: uninstall-gk
 placementRef:
-  name: compliance-api-uninstall-gk
+  name: uninstall-gk
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
-  - name: compliance-api-uninstall-gk
+  - name: uninstall-gk
     apiGroup: policy.open-cluster-management.io
     kind: Policy


### PR DESCRIPTION
This leverages OperatorPolicy to uninstall the Gatekeeper operator along with some ConfigurationPolicy to remove other related objects.

Relates:
https://issues.redhat.com/browse/ACM-13584