### PR TITLE
fix: update `acm-cli` check for additional CLI

### DIFF
--- a/build/codebase-check.sh
+++ b/build/codebase-check.sh
@@ -34,7 +34,7 @@ currentReleaseRefs() {
 	# Get the current version from CURRENT_VERSION file
 	CURRENT_VERSION="$(cat CURRENT_VERSION)"
 	EXPECTED_BRANCH="release-${CURRENT_VERSION}"
-	EXPECTED_OUTPUT=$(printf "%s\n%s" "${EXPECTED_BRANCH}" "${EXPECTED_BRANCH}")
+	EXPECTED_OUTPUT=$(printf "%s\n%s\n%s" "${EXPECTED_BRANCH}" "${EXPECTED_BRANCH}" "${EXPECTED_BRANCH}")
 
 	# Fetch the .gitmodules file from acm-cli repository
 	GITMODULES_URL="https://raw.githubusercontent.com/stolostron/acm-cli/main/.gitmodules"


### PR DESCRIPTION
Resolves this message:
```
ERROR: acm-cli submodule branches are set to 'release-5.0/release-5.0/release-5.0', expected 'release-5.0/release-5.0'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build validation logic for submodule branch reference checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->