### PR TITLE
chore: reduce MintMaker updates

### DIFF
--- a/.github/renovate_default.json
+++ b/.github/renovate_default.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "America/New_York",
-  "schedule": "weekly",
+  "schedule": [
+    "* 0-9 1-7,15-21 * 1"
+  ],
   "dockerfile": {
     "enabled": false
   },


### PR DESCRIPTION
Move from a weekly to bi-weekly schedule

This will occasionally have a three-week gap when a month has 5 Mondays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the scheduling configuration for dependency updates to use a more targeted cron-based schedule instead of a simple weekly cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->