### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.25-linux
+  tag: go1.26-linux

--- a/build/Dockerfile.e2etest
+++ b/build/Dockerfile.e2etest
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
 # Stage 1: Use image builder to retrieve Go binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 # Stage 2: Copy Go binaries and run tests on ubi-minimal
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/governance-policy-framework
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain from 1.25 to 1.26 for builds, including the Go-based builder image used in CI and end-to-end test builds.
  * Updated the Go module toolchain directive to align with the new 1.26 toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->