### PR TITLE
chore: pin GitHub Actions to digests

### DIFF
--- a/.github/renovate_default.json
+++ b/.github/renovate_default.json
@@ -34,7 +34,8 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub actions"
+      "groupName": "GitHub actions",
+      "pinDigests": true
     }
   ]
 }


### PR DESCRIPTION
ref: https://docs.renovatebot.com/configuration-options/#pindigests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update settings for GitHub Actions by pinning action digests for added security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->