### PR TITLE
fix: continue on empty commits

### DIFF
--- a/build/main-branch-sync/repo-bulk-update.sh
+++ b/build/main-branch-sync/repo-bulk-update.sh
@@ -308,7 +308,10 @@ for repo in ${repos}; do
       fi
 
       # shellcheck disable=SC2086 # amend contains multiple arguments
-      ${git} commit -s -S -a -m "${commit_msg}" -m "${commit_body}"
+      ${git} commit -s -S -a -m "${commit_msg}" -m "${commit_body}" || {
+        echo "ERROR: commit failed. Skipping pull request."
+        continue
+      }
       output=$(${git} push origin "${head_branch}" 2>&1) || {
         printf "ERROR $?: %s\n" "${output}"
         exit 1


### PR DESCRIPTION
Empty commits in the bulk update script is causing the script to exit early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk repository updates to handle commit failures gracefully.
  * If a commit does not succeed, the process now skips push and pull request creation for that repository and continues with the next one.
  * Added a clear error message when a commit fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->