### PR TITLE
chore: rename bot to `grc-security`

### DIFF
--- a/build/main-branch-sync/README.md
+++ b/build/main-branch-sync/README.md
@@ -82,7 +82,7 @@ build/main-branch-sync/repo-bulk-update.sh --help
 - **Prerequisites**:
   - CLIs installed: `gh`, `aws`, `oc`, `jq`
   - Log in to the Collective cluster
-  - Log in to GitHub with username `acm-grc-security`
+  - Log in to GitHub with username `grc-security`
 
 1. Run the [`rotate-secrets.sh`](./rotate-secrets.sh) script. (It will prompt for the new GitHub and
    SonarCloud tokens, regenerate the AWS token, rotate the Collective tokens, rotate the GitHub

--- a/build/main-branch-sync/rotate-secrets.sh
+++ b/build/main-branch-sync/rotate-secrets.sh
@@ -16,14 +16,6 @@ for CLI in gh aws jq yq oc; do
   fi
 done
 
-# Verify the oc version
-MAJOR_OC=$(oc version -o json | jq -r '.clientVersion.gitVersion' | grep -o "[0-9]\+\.[0-9]\+" | sed 's/\.[0-9]*$//')
-MINOR_OC=$(oc version -o json | jq -r '.clientVersion.gitVersion' | grep -o "[0-9]\+\.[0-9]\+" | sed 's/^[0-9]*\.//')
-if ((MAJOR_OC < 4)) || ((MAJOR_OC == 4)) && ((MINOR_OC < 11)); then
-  echo "The openshift CLI must be at version 4.11 or later. Current version: $(oc version -o json | jq -r '.clientVersion.gitVersion')"
-  exit 1
-fi
-
 # Verify AWS access
 AWS_LOGIN_USER=$(aws iam list-access-keys | jq -r '.AccessKeyMetadata[0].UserName')
 

--- a/build/main-branch-sync/rotate-secrets.sh
+++ b/build/main-branch-sync/rotate-secrets.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-GITHUB_BOT_USER="acm-grc-security"
+GITHUB_BOT_USER="grc-security"
 AWS_BOT_USER="ocm-grc-aws-kind-bot"
 COLLECTIVE_NS="acm-grc-security"
 
@@ -84,7 +84,7 @@ oc delete secret "$(oc get sa "${SERVICE_ACCT_NAME}" -n "${COLLECTIVE_NS}" -o js
 
 # Update credentials on Collective using regenerated tokens
 oc delete secret rhacmstackem-github-secret policy-grc-aws-creds -n "${COLLECTIVE_NS}"
-oc create secret generic rhacmstackem-github-secret -n "${COLLECTIVE_NS}" --from-literal=user=acm-grc-security --from-literal=token="${COLLECTIVE_GH_TOKEN}"
+oc create secret generic rhacmstackem-github-secret -n "${COLLECTIVE_NS}" --from-literal=user=grc-security --from-literal=token="${COLLECTIVE_GH_TOKEN}"
 oc create secret generic policy-grc-aws-creds -n "${COLLECTIVE_NS}" --from-literal=aws_access_key_id="${AWS_ACCESS_KEY_ID}" --from-literal=aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
 
 # Update credentials for each existing cluster deployment

--- a/build/pull-requests.sh
+++ b/build/pull-requests.sh
@@ -79,7 +79,7 @@ dependabot[bot]
 red-hat-konflux[bot]
 magic-mirror-bot[bot]
 acm-cicd-prow-bot
-acm-grc-security
+grc-security
 openshift-cherrypick-robot
 '
 bot_users=$(echo "${bot_users}" | jq -Rsc 'split("\n") | map(select(. != ""))')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automation to recognize the current GitHub bot account name.
  * Revised secret rotation instructions and generated secret metadata to use the current account name.
  * Corrected pull request categorization for activity from the updated bot account.
  * Removed the prior OpenShift client version check from the secret rotation process to avoid unnecessary blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->