### PR TITLE
doc: add policyset explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If desired, users can request automated actions to perform when a policy is viol
 
 ## The Policy CRDs
 
+### Policy
+
 The `Policy` is the Custom Resource Definition (CRD), created for policy framework controllers to
 monitor. It acts as a vehicle to deliver policies to managed cluster and collect results to send to
 the hub cluster.
@@ -79,6 +81,8 @@ spec:
                         - containerPort: 80
 ```
 
+### PlacementBinding
+
 The `PlacementBinding` CRD is used to bind the `Policy` with a `Placement`. Only a bound `Policy` is
 distributed to a managed cluster by the policy framework.
 
@@ -98,6 +102,8 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ```
+
+### Placement
 
 The `Placement` CRD is used to determine the target clusters to distribute policies to.
 
@@ -121,6 +127,92 @@ spec:
       operator: Exists
 ```
 
+### PolicySet
+
+The `PolicySet` CRD is used to group multiple policies and distribute them to a set of clusters. Each `Policy` in the `PolicySet` must be created in the same namespace as the `PolicySet`.
+
+The following is an example `PolicySet` object specification:
+
+```yaml
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: policy-set-pod
+spec:
+  policies:
+    - name: policy-pod
+    - name: policy-pod-security
+    - name: policy-pod-network
+```
+
+ When a `PolicySet` is bound to a `Placement` with a `PlacementBinding`, enabled policies in the `PolicySet` are distributed to the clusters in the `Placement`, subject to exclusions. The `PolicySet` reports the overall compliance of the policies in the set.
+
+The following example shows how to bind the `PolicySet` using `PlacementBinding`:
+
+```yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-set-pod
+placementRef:
+  name: placement-policy-set-pod
+  kind: Placement
+  apiGroup: cluster.open-cluster-management.io
+subjects:
+  - name: policy-set-pod
+    kind: PolicySet
+    apiGroup: policy.open-cluster-management.io
+```
+
+Generally, policies within a `PolicySet` rely on the `Placement` bound to the `PolicySet`. It is not recommended to have individual placement bindings or placements for policies within a `PolicySet`, because it can lead to unexpected behavior if the multiple placements conflict with each other.
+
+#### PolicySet Exclusions
+
+The `Policy` CRD supports disabling a policy by setting the `disabled` field to `true`. When a policy is disabled, the policy will not be distributed to any clusters in the `Placement` bound to the `PolicySet`. This is useful when a policy is not ready to be enforced yet, or is causing disruption to **all** clusters in the `Placement`.
+
+```yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-pod-network
+spec:
+  remediationAction: enforce
+  disabled: true # disabled on all clusters in the Placement bound to the PolicySet
+```
+
+For greater operational flexibility, the `PolicySet` CRD supports excluding a policy from a `PolicySet` by setting the `exclusions` field. When a policy is excluded, the policy will not be distributed to the list of  `clusterNames` in the exclusion. This is useful when a policy in a `PolicySet` is causing disruption to specific clusters in the `Placement`, and it is not practical to remove the policy from the `PolicySet` or disable the policy for all clusters in the `Placement`.
+
+The following example shows a `PolicySet` object with exclusions. The optional `reason` field provides a human-readable explanation for each exclusion:
+
+```yaml
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: policy-set-pod
+spec:
+  policies:
+    - name: policy-pod
+    - name: policy-pod-security
+    - name: policy-pod-network
+  exclusions:
+    - clusterNames:
+        - cluster1
+        - cluster2
+      policyName: policy-pod-network
+      reason: "incident mitigation"
+    - clusterNames:
+        - cluster3
+      policyName: policy-pod-security
+      reason: "upgrade in progress"
+```
+
+Considerations when using exclusions:
+- The exclusion will be ignored if another `PlacementBinding` binds the `Policy` to another `Placement` that includes the excluded cluster.
+- Exclusions are intended for short-term use only. If a policy (or multiple policies) require a different set of target clusters long-term, it is recommended to remove the policies from the `PolicySet` and create a new `Placement` with the new set of target clusters.
+- Disabling a `Policy` will disable the policy on all clusters in the `Placement` bound to the `PolicySet`, regardless of whether an exclusion is applied.
+- The per-cluster `status` entry for a root `Policy` on an excluded cluster will be `Unknown`.
+- When a cluster is removed from the exclusion list, the policy will be distributed to the cluster again if the cluster remains selected by the `Placement`.
+
 ## How to install it
 
 You can find installation instructions from
@@ -132,5 +224,5 @@ You can find more policies or contribute to the open repository,
 [policy-collection](https://github.com/stolostron/policy-collection).
 
 <!---
-Date: 09/18/2024
+Date: 08/05/2026
 -->


### PR DESCRIPTION
Follow up to https://github.com/open-cluster-management-io/governance-policy-propagator/pull/331

Let me know if there is a better location for these docs, or if a more detailed example of status would be helpful here.

Adds minimal policyset examples and usage for PolicySet exclusions

ref: https://redhat.atlassian.net/browse/ACM-37779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Policy, PlacementBinding, and Placement concepts.
  * Documented the PolicySet resource, including grouping, placement bindings, examples, exclusions, exclusion reasons, and operational considerations.
  * Updated the documentation date to August 5, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->